### PR TITLE
Expose an HttpStatus to Connect method in DevicePortal

### DIFF
--- a/WindowsDevicePortalWrapper/TestAppXbox/Program.cs
+++ b/WindowsDevicePortalWrapper/TestAppXbox/Program.cs
@@ -2,14 +2,14 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 
 namespace TestApp
 {
-    class Program : IDisposable
+    class Program
     {
-        private ManualResetEvent _mreConnected = new ManualResetEvent(false);
         private bool _verbose = false;
 
         private enum OperationType
@@ -65,13 +65,22 @@ namespace TestApp
             app._verbose = parameters.HasFlag(ParameterHelper.VerboseFlag);
 
             DevicePortal portal = new DevicePortal(new DevicePortalConnection(parameters.GetParameterValue(ParameterHelper.IpOrHostname), parameters.GetParameterValue(ParameterHelper.WdpUser), parameters.GetParameterValue(ParameterHelper.WdpPassword)));
-            portal.ConnectionStatus += app.ConnectionStatusHandler;
 
-            app._mreConnected.Reset();
-            Task t = portal.Connect();
-            app._mreConnected.WaitOne();
+            Task connectTask = portal.Connect(null, null, false);
+            connectTask.Wait();
 
-            if (operation == OperationType.InfoOperation)
+            if (portal.ConnectionHttpStatusCode != HttpStatusCode.OK)
+            {
+                if (portal.ConnectionHttpStatusCode != 0)
+                {
+                    Console.WriteLine(String.Format("Failed to connect to WDP with HTTP Status code: {0}", portal.ConnectionHttpStatusCode));
+                }
+                else
+                {
+                    Console.WriteLine("Failed to connect to WDP for unknown reason.");
+                }
+            }
+            else if (operation == OperationType.InfoOperation)
             {
                 Console.WriteLine("OS version: " + portal.OperatingSystemVersion);
                 Console.WriteLine("Platform: " + portal.Platform.ToString());
@@ -83,35 +92,6 @@ namespace TestApp
             else if (operation == OperationType.UserOperation)
             {
                 UserOperation.HandleOperation(portal, parameters);
-            }
-        }
-
-        public void Dispose()
-        {
-            Dispose(true);
-            GC.SuppressFinalize(this);
-        }
-
-        protected virtual void Dispose(Boolean disposing)
-        {
-            if (disposing)
-            { 
-                _mreConnected?.Dispose();
-                _mreConnected = null;
-            }
-        }
-
-        private void ConnectionStatusHandler(Object sender, DeviceConnectionStatusEventArgs args)
-        {
-            if (_verbose)
-            {
-                Console.WriteLine(args.Message);
-            }
-
-            if ((args.Status == DeviceConnectionStatus.Connected) ||
-                (args.Status == DeviceConnectionStatus.Failed))
-            {
-                _mreConnected.Set();
             }
         }
 

--- a/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper/DevicePortal.cs
+++ b/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper/DevicePortal.cs
@@ -16,6 +16,8 @@ namespace Microsoft.Tools.WindowsDevicePortal
 
         public DeviceConnectionStatusEventHandler ConnectionStatus;
 
+        public HttpStatusCode ConnectionHttpStatusCode = HttpStatusCode.OK;
+
         public String Address 
         {
             get { return _deviceConnection.Connection.Authority; }
@@ -121,12 +123,13 @@ namespace Microsoft.Tools.WindowsDevicePortal
             {
                 DevicePortalException dpe = e as DevicePortalException;
 
-                HttpStatusCode status = (HttpStatusCode)0;
-                Uri request = null;
                 if (dpe != null)
                 {
-                    status = dpe.StatusCode;
-                    request = dpe.RequestUri;
+                    ConnectionHttpStatusCode = dpe.StatusCode;
+                }
+                else
+                {
+                    ConnectionHttpStatusCode = (HttpStatusCode)0;
                 }
 
                 SendConnectionStatus(DeviceConnectionStatus.Failed,

--- a/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper/HttpRest/RestGet.cs
+++ b/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper/HttpRest/RestGet.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Tools.WindowsDevicePortal
                 {
                     if (!response.IsSuccessStatusCode)
                     {
-                        throw new InvalidOperationException();
+                        throw new DevicePortalException(response);
                     }
 
                     using (HttpContent content = response.Content)


### PR DESCRIPTION
This gives callers the ability to determine why a connect failed (Eg Http Unathorized means the creds aren't valid).
