### PR TITLE
Adds some Xbox specific test mocks to establish the pattern

### DIFF
--- a/WindowsDevicePortalWrapper/UnitTestProject/BaseTests.cs
+++ b/WindowsDevicePortalWrapper/UnitTestProject/BaseTests.cs
@@ -5,6 +5,7 @@
 //----------------------------------------------------------------------------------------------
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using static Microsoft.Tools.WindowsDevicePortal.DevicePortal;
 
 namespace Microsoft.Tools.WindowsDevicePortal.Tests
 {
@@ -22,7 +23,29 @@ namespace Microsoft.Tools.WindowsDevicePortal.Tests
         /// </summary>
         public BaseTests()
         {
-            TestHelpers.EstablishMockConnection();
+            TestHelpers.EstablishMockConnection(this.PlatformType, this.OperatingSystemVersion);
+        }
+
+        /// <summary>
+        /// Gets the overridable Platform type.
+        /// </summary>
+        protected virtual DevicePortalPlatforms PlatformType
+        {
+            get
+            {
+                return DevicePortalPlatforms.Unknown;
+            }
+        }
+
+        /// <summary>
+        /// Gets the overridable OS Version.
+        /// </summary>
+        protected virtual string OperatingSystemVersion
+        {
+            get
+            {
+                return null;
+            }
         }
 
         /// <summary>

--- a/WindowsDevicePortalWrapper/UnitTestProject/Device-VersionTests/XboxOne/XboxHelpers.cs
+++ b/WindowsDevicePortalWrapper/UnitTestProject/Device-VersionTests/XboxOne/XboxHelpers.cs
@@ -1,0 +1,38 @@
+﻿//----------------------------------------------------------------------------------------------
+// <copyright file="XboxHelpers.cs" company="Microsoft Corporation">
+//     Licensed under the MIT License. See LICENSE.TXT in the project root license information.
+// </copyright>
+//----------------------------------------------------------------------------------------------
+
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using static Microsoft.Tools.WindowsDevicePortal.DevicePortal;
+
+namespace Microsoft.Tools.WindowsDevicePortal.Tests
+{
+    /// <summary>
+    /// Helpers for Xbox tests.
+    /// </summary>
+    public class XboxHelpers
+    {
+        /// <summary>
+        /// Helper method for verifying OS info based on a given version.
+        /// </summary>
+        /// <param name="operatingSystemVersion">The version of the OS we are targeting.</param>
+        public static void VerifyOsInformation(string operatingSystemVersion)
+        {
+            TestHelpers.MockHttpResponder.AddMockResponse(DevicePortal.MachineNameApi, DevicePortalPlatforms.XboxOne, operatingSystemVersion);
+
+            Task<string> getNameTask = TestHelpers.Portal.GetDeviceName();
+            getNameTask.Wait();
+
+            string formattedOsVersion = TestHelpers.Portal.OperatingSystemVersion;
+            formattedOsVersion = formattedOsVersion.Replace('.', '_');
+            formattedOsVersion = formattedOsVersion.Replace('-', '_');
+
+            Assert.AreEqual(operatingSystemVersion, formattedOsVersion);
+            Assert.AreEqual(DevicePortalPlatforms.XboxOne, TestHelpers.Portal.Platform);
+            Assert.AreEqual("XboxOneName", getNameTask.Result);
+        }
+    }
+}

--- a/WindowsDevicePortalWrapper/UnitTestProject/Device-VersionTests/XboxOne/XboxOne_14385_1002_amd64fre_rs1_xbox_rel_1608_160709_1700.cs
+++ b/WindowsDevicePortalWrapper/UnitTestProject/Device-VersionTests/XboxOne/XboxOne_14385_1002_amd64fre_rs1_xbox_rel_1608_160709_1700.cs
@@ -1,0 +1,79 @@
+﻿//----------------------------------------------------------------------------------------------
+// <copyright file="XboxOne_14385_1002_amd64fre_rs1_xbox_rel_1608_160709_1700.cs" company="Microsoft Corporation">
+//     Licensed under the MIT License. See LICENSE.TXT in the project root license information.
+// </copyright>
+//----------------------------------------------------------------------------------------------
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using static Microsoft.Tools.WindowsDevicePortal.DevicePortal;
+
+namespace Microsoft.Tools.WindowsDevicePortal.Tests
+{
+    /// <summary>
+    /// Test class for XboxOne_14385_1002_amd64fre_rs1_xbox_rel_1608_160709_1700 version
+    /// </summary>
+    [TestClass]
+    public class XboxOne_14385_1002_amd64fre_rs1_xbox_rel_1608_160709_1700 : BaseTests
+    {
+        /// <summary>
+        /// Gets the Platform type these tests are targeting.
+        /// </summary>
+        protected override DevicePortalPlatforms PlatformType
+        {
+            get
+            {
+                return DevicePortalPlatforms.XboxOne;
+            }
+        }
+
+        /// <summary>
+        /// Gets the OS Version these tests are targeting.
+        /// </summary>
+        protected override string OperatingSystemVersion
+        {
+            get
+            {
+                return "14385_1002_amd64fre_rs1_xbox_rel_1608_160709_1700";
+            }
+        }
+
+        /// <summary>
+        /// Gets a mock list of users and verifies it comes back as 
+        /// expected from the raw response content using a mock generated
+        /// on an Xbox One running the 1608 OS recovery.
+        /// </summary>
+        [TestMethod]
+        public void GetXboxLiveUserListTest_XboxOne_1608()
+        {
+            TestHelpers.MockHttpResponder.AddMockResponse(DevicePortal.XboxLiveUserApi, this.PlatformType, this.OperatingSystemVersion);
+
+            Task<UserList> getUserTask = TestHelpers.Portal.GetXboxLiveUsers();
+            getUserTask.Wait();
+
+            Assert.AreEqual(TaskStatus.RanToCompletion, getUserTask.Status);
+
+            List<UserInfo> users = getUserTask.Result.Users;
+
+            // Check some known things about this response.
+            Assert.AreEqual(1, users.Count);
+
+            Assert.AreEqual("TestUser@XboxTestDomain.com", users[0].EmailAddress);
+            Assert.AreEqual("TestGamertag", users[0].Gamertag);
+            Assert.AreEqual(20u, users[0].UserId);
+            Assert.AreEqual("1234567890123456", users[0].XboxUserId);
+            Assert.AreEqual(false, users[0].SignedIn);
+            Assert.AreEqual(false, users[0].AutoSignIn);
+        }
+
+        /// <summary>
+        /// Basic test of 
+        /// </summary>
+        [TestMethod]
+        public void GetOsInfo_XboxOne_1608()
+        {
+            XboxHelpers.VerifyOsInformation(this.OperatingSystemVersion);
+        }
+    }
+}

--- a/WindowsDevicePortalWrapper/UnitTestProject/MockData/Defaults/api-os-info_Default.dat
+++ b/WindowsDevicePortalWrapper/UnitTestProject/MockData/Defaults/api-os-info_Default.dat
@@ -1,1 +1,1 @@
-{"ComputerName" : "XboxOne", "Language" : "en-US", "OsEdition" : "SystemOS", "OsEditionId" : 2882382797, "OsVersion" : "14381.1003.amd64fre.rs1_xbox_rel_1610.160704-1900", "Platform" : "Xbox One"}
+{"ComputerName" : "MyComputerName", "Language" : "en-US", "OsEdition" : "SystemOS", "OsEditionId" : 2882382797, "OsVersion" : "12345.1111.amd64fre.rs1.2123456-1111", "Platform" : "SomePlatform"}

--- a/WindowsDevicePortalWrapper/UnitTestProject/MockData/ReadMe.txt
+++ b/WindowsDevicePortalWrapper/UnitTestProject/MockData/ReadMe.txt
@@ -1,0 +1,5 @@
+﻿Defaults contains mocks that are device and release agnostic to allow some 'general' testing of APIs.
+
+Each device type can have its own folder as well for device specific responses, and subfolders 
+under the device folder for release specific responses. This enables back-compat testing to ensure
+new changes to the wrappers still operate as expected with responses from old devices.

--- a/WindowsDevicePortalWrapper/UnitTestProject/MockData/XboxOne/14385_1002_amd64fre_rs1_xbox_rel_1608_160709_1700/api_os_devicefamily_XboxOne_14385_1002_amd64fre_rs1_xbox_rel_1608_160709_1700.dat
+++ b/WindowsDevicePortalWrapper/UnitTestProject/MockData/XboxOne/14385_1002_amd64fre_rs1_xbox_rel_1608_160709_1700/api_os_devicefamily_XboxOne_14385_1002_amd64fre_rs1_xbox_rel_1608_160709_1700.dat
@@ -1,0 +1,1 @@
+{"DeviceType" : "Windows.Xbox"}

--- a/WindowsDevicePortalWrapper/UnitTestProject/MockData/XboxOne/14385_1002_amd64fre_rs1_xbox_rel_1608_160709_1700/api_os_info_XboxOne_14385_1002_amd64fre_rs1_xbox_rel_1608_160709_1700.dat
+++ b/WindowsDevicePortalWrapper/UnitTestProject/MockData/XboxOne/14385_1002_amd64fre_rs1_xbox_rel_1608_160709_1700/api_os_info_XboxOne_14385_1002_amd64fre_rs1_xbox_rel_1608_160709_1700.dat
@@ -1,0 +1,1 @@
+{"ComputerName" : "XboxOneName", "Language" : "en-US", "OsEdition" : "SystemOS", "OsEditionId" : 2882382797, "OsVersion" : "14385.1002.amd64fre.rs1_xbox_rel_1608.160709-1700", "Platform" : "Xbox One"}

--- a/WindowsDevicePortalWrapper/UnitTestProject/MockData/XboxOne/14385_1002_amd64fre_rs1_xbox_rel_1608_160709_1700/api_os_machinename_XboxOne_14385_1002_amd64fre_rs1_xbox_rel_1608_160709_1700.dat
+++ b/WindowsDevicePortalWrapper/UnitTestProject/MockData/XboxOne/14385_1002_amd64fre_rs1_xbox_rel_1608_160709_1700/api_os_machinename_XboxOne_14385_1002_amd64fre_rs1_xbox_rel_1608_160709_1700.dat
@@ -1,0 +1,1 @@
+{"ComputerName" : "XboxOneName"}

--- a/WindowsDevicePortalWrapper/UnitTestProject/MockData/XboxOne/14385_1002_amd64fre_rs1_xbox_rel_1608_160709_1700/ext_user_XboxOne_14385_1002_amd64fre_rs1_xbox_rel_1608_160709_1700.dat
+++ b/WindowsDevicePortalWrapper/UnitTestProject/MockData/XboxOne/14385_1002_amd64fre_rs1_xbox_rel_1608_160709_1700/ext_user_XboxOne_14385_1002_amd64fre_rs1_xbox_rel_1608_160709_1700.dat
@@ -1,0 +1,1 @@
+{"Users":[{"UserId":20,"EmailAddress":"TestUser@XboxTestDomain.com","AutoSignIn":false,"Gamertag":"TestGamertag","XboxUserId":"1234567890123456","SignedIn":false}]}

--- a/WindowsDevicePortalWrapper/UnitTestProject/TestHelpers.cs
+++ b/WindowsDevicePortalWrapper/UnitTestProject/TestHelpers.cs
@@ -7,6 +7,7 @@
 using System.Net;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using static Microsoft.Tools.WindowsDevicePortal.DevicePortal;
 
 namespace Microsoft.Tools.WindowsDevicePortal.Tests
 {
@@ -28,11 +29,13 @@ namespace Microsoft.Tools.WindowsDevicePortal.Tests
         /// <summary>
         /// Helper for establishing a mock connection to a DevicePortal object.
         /// </summary>
-        public static void EstablishMockConnection()
+        /// <param name="platform">The platform we are pretending to connect to.</param>
+        /// <param name="operatingSystemVersion">The OS we are pretending it is running.</param>
+        public static void EstablishMockConnection(DevicePortalPlatforms platform, string operatingSystemVersion)
         {
             TestHelpers.MockHttpResponder = new MockHttpResponder();
-            TestHelpers.MockHttpResponder.AddMockResponse(DevicePortal.DeviceFamilyApi);
-            TestHelpers.MockHttpResponder.AddMockResponse(DevicePortal.OsInfoApi);
+            TestHelpers.MockHttpResponder.AddMockResponse(DevicePortal.DeviceFamilyApi, platform, operatingSystemVersion);
+            TestHelpers.MockHttpResponder.AddMockResponse(DevicePortal.OsInfoApi, platform, operatingSystemVersion);
 
             TestHelpers.Portal = new DevicePortal(new MockDevicePortalConnection());
 

--- a/WindowsDevicePortalWrapper/UnitTestProject/UnitTestProject.csproj
+++ b/WindowsDevicePortalWrapper/UnitTestProject/UnitTestProject.csproj
@@ -58,6 +58,8 @@
   </Choose>
   <ItemGroup>
     <Compile Include="BaseTests.cs" />
+    <Compile Include="Device-VersionTests\XboxOne\XboxHelpers.cs" />
+    <Compile Include="Device-VersionTests\XboxOne\XboxOne_14385_1002_amd64fre_rs1_xbox_rel_1608_160709_1700.cs" />
     <Compile Include="MockHttpResponder.cs" />
     <Compile Include="WDPMockImplementations\AppDeployment.cs" />
     <Compile Include="WDPMockImplementations\CertificateHandling.cs" />
@@ -88,6 +90,22 @@
     <None Include="MockData\Defaults\ext-user_Default.dat">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="MockData\XboxOne\14385_1002_amd64fre_rs1_xbox_rel_1608_160709_1700\api_os_devicefamily_XboxOne_14385_1002_amd64fre_rs1_xbox_rel_1608_160709_1700.dat">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="MockData\XboxOne\14385_1002_amd64fre_rs1_xbox_rel_1608_160709_1700\api_os_info_XboxOne_14385_1002_amd64fre_rs1_xbox_rel_1608_160709_1700.dat">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="MockData\XboxOne\14385_1002_amd64fre_rs1_xbox_rel_1608_160709_1700\api_os_machinename_XboxOne_14385_1002_amd64fre_rs1_xbox_rel_1608_160709_1700.dat">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="MockData\XboxOne\14385_1002_amd64fre_rs1_xbox_rel_1608_160709_1700\ext_user_XboxOne_14385_1002_amd64fre_rs1_xbox_rel_1608_160709_1700.dat">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+  <ItemGroup />
+  <ItemGroup>
+    <Content Include="MockData\ReadMe.txt" />
   </ItemGroup>
   <Choose>
     <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">

--- a/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper.Shared/DevicePortal.cs
+++ b/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper.Shared/DevicePortal.cs
@@ -256,7 +256,13 @@ namespace Microsoft.Tools.WindowsDevicePortal
 
             using (Stream dataStream = await this.Get(uri))
             {
-                string filename = endpoint.Replace('/', '-') + "_" + this.DeviceFamily + "_" + this.OperatingSystemVersion + ".dat";
+                // Create the filename as DeviceFamily_OSVersion.dat, replacing '/', '.', and '-' with '_' so
+                // we can create a class with the same name as this Device/OS pair for tests.
+                string filename = endpoint + "_" + this.Platform.ToString() + "_" + this.OperatingSystemVersion;
+                filename = filename.Replace('/', '_');
+                filename = filename.Replace('-', '_');
+                filename = filename.Replace('.', '_');
+                filename += ".dat";
                 string filepath = Path.Combine(directory, filename);
 
                 using (var fileStream = File.Create(filepath))


### PR DESCRIPTION
Adds a couple simple tests for a specific version of xbox_rel_1508 (the one that my retail devkit in the developer preview program has).

My intention would be that we add new tests against newly generated mocks anytime a release seems to have different response behavior or for some other reason we want to test that release specifically.
