### PR TITLE
Renamed HttpOperations to HttpMethods and have ApplyHttpHeaders use it

### DIFF
--- a/WindowsDevicePortalWrapper/MockDataGenerator/Program.cs
+++ b/WindowsDevicePortalWrapper/MockDataGenerator/Program.cs
@@ -113,16 +113,16 @@ namespace MockDataGenerator
 
             if (parameters.HasParameter("endpoint"))
             {
-                HttpOperations httpOperation = HttpOperations.Get;
+                HttpMethods httpMethod = HttpMethods.Get;
                 string endpoint = parameters.GetParameterValue("endpoint");
 
                 if (endpoint.StartsWith(WebSocketOpertionPrefix, StringComparison.OrdinalIgnoreCase))
                 {
-                    httpOperation = HttpOperations.WebSocket;
+                    httpMethod = HttpMethods.WebSocket;
                     endpoint = endpoint.Substring(WebSocketOpertionPrefix.Length);
                 }
 
-                Task saveResponseTask = portal.SaveEndpointResponseToFile(endpoint, directory, httpOperation);
+                Task saveResponseTask = portal.SaveEndpointResponseToFile(endpoint, directory, httpMethod);
                 saveResponseTask.Wait();
             }
             else
@@ -130,17 +130,17 @@ namespace MockDataGenerator
                 foreach (string endpoint in Endpoints)
                 {
                     string finalEndpoint = endpoint;
-                    HttpOperations httpOperation = HttpOperations.Get;
+                    HttpMethods httpMethod = HttpMethods.Get;
 
                     if (endpoint.StartsWith(WebSocketOpertionPrefix, StringComparison.OrdinalIgnoreCase))
                     {
-                        httpOperation = HttpOperations.WebSocket;
+                        httpMethod = HttpMethods.WebSocket;
                         finalEndpoint = endpoint.Substring(WebSocketOpertionPrefix.Length);
                     }
 
                     try
                     {
-                        Task saveResponseTask = portal.SaveEndpointResponseToFile(finalEndpoint, directory, httpOperation);
+                        Task saveResponseTask = portal.SaveEndpointResponseToFile(finalEndpoint, directory, httpMethod);
                         saveResponseTask.Wait();
                     }
                     catch (Exception e)

--- a/WindowsDevicePortalWrapper/UnitTestProject/Core/AppFileExplorerTests.cs
+++ b/WindowsDevicePortalWrapper/UnitTestProject/Core/AppFileExplorerTests.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Tools.WindowsDevicePortal.Tests
 
             response.Content = content;
 
-            TestHelpers.MockHttpResponder.AddMockResponse(DevicePortal.KnownFoldersApi, response, HttpOperations.Get);
+            TestHelpers.MockHttpResponder.AddMockResponse(DevicePortal.KnownFoldersApi, response, HttpMethods.Get);
 
             Task<KnownFolders> getKnownFoldersTask = TestHelpers.Portal.GetKnownFolders();
             getKnownFoldersTask.Wait();
@@ -69,7 +69,7 @@ namespace Microsoft.Tools.WindowsDevicePortal.Tests
 
             response.Content = content;
 
-            TestHelpers.MockHttpResponder.AddMockResponse(DevicePortal.GetFilesApi, response, HttpOperations.Get);
+            TestHelpers.MockHttpResponder.AddMockResponse(DevicePortal.GetFilesApi, response, HttpMethods.Get);
 
             Task<FolderContents> getFolderContentsTask = TestHelpers.Portal.GetFolderContents("KnownFolderOne");
             getFolderContentsTask.Wait();
@@ -117,7 +117,7 @@ namespace Microsoft.Tools.WindowsDevicePortal.Tests
             HttpContent content = new StreamContent(stream);
             response.Content = content;
 
-            TestHelpers.MockHttpResponder.AddMockResponse(DevicePortal.GetFileApi, response, HttpOperations.Get);
+            TestHelpers.MockHttpResponder.AddMockResponse(DevicePortal.GetFileApi, response, HttpMethods.Get);
 
             Task<Stream> getFileTask = TestHelpers.Portal.GetFile("knownfolder", "FileToDownload.txt", "SubFolder\\SubFolder2");
             getFileTask.Wait();
@@ -135,7 +135,7 @@ namespace Microsoft.Tools.WindowsDevicePortal.Tests
         {
             HttpResponseMessage response = new HttpResponseMessage(HttpStatusCode.OK);
 
-            TestHelpers.MockHttpResponder.AddMockResponse(DevicePortal.GetFileApi, response, HttpOperations.Post);
+            TestHelpers.MockHttpResponder.AddMockResponse(DevicePortal.GetFileApi, response, HttpMethods.Post);
 
             Task uploadFileTask = TestHelpers.Portal.UploadFile("knownfolder", "MockData\\Defaults\\api_os_devicefamily_Default.dat", "SubFolder\\SubFolder2");
             uploadFileTask.Wait();
@@ -152,7 +152,7 @@ namespace Microsoft.Tools.WindowsDevicePortal.Tests
         {
             HttpResponseMessage response = new HttpResponseMessage(HttpStatusCode.OK);
 
-            TestHelpers.MockHttpResponder.AddMockResponse(DevicePortal.GetFileApi, response, HttpOperations.Post);
+            TestHelpers.MockHttpResponder.AddMockResponse(DevicePortal.GetFileApi, response, HttpMethods.Post);
 
             try
             {
@@ -175,7 +175,7 @@ namespace Microsoft.Tools.WindowsDevicePortal.Tests
         {
             HttpResponseMessage response = new HttpResponseMessage(HttpStatusCode.OK);
 
-            TestHelpers.MockHttpResponder.AddMockResponse(DevicePortal.GetFileApi, response, HttpOperations.Delete);
+            TestHelpers.MockHttpResponder.AddMockResponse(DevicePortal.GetFileApi, response, HttpMethods.Delete);
 
             Task deleteFileTask = TestHelpers.Portal.DeleteFile("knownfolder", "FileToDelete.txt", "SubFolder\\SubFolder2");
             deleteFileTask.Wait();
@@ -191,7 +191,7 @@ namespace Microsoft.Tools.WindowsDevicePortal.Tests
         {
             HttpResponseMessage response = new HttpResponseMessage(HttpStatusCode.OK);
 
-            TestHelpers.MockHttpResponder.AddMockResponse(DevicePortal.RenameFileApi, response, HttpOperations.Post);
+            TestHelpers.MockHttpResponder.AddMockResponse(DevicePortal.RenameFileApi, response, HttpMethods.Post);
 
             Task renameFileTask = TestHelpers.Portal.RenameFile("knownfolder", "FileToRename.txt", "NewFileName.txt", "SubFolder\\SubFolder2");
             renameFileTask.Wait();

--- a/WindowsDevicePortalWrapper/UnitTestProject/Core/OsInformationTests.cs
+++ b/WindowsDevicePortalWrapper/UnitTestProject/Core/OsInformationTests.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Tools.WindowsDevicePortal.Tests
         [TestMethod]
         public void OsInformationTest()
         {
-            TestHelpers.MockHttpResponder.AddMockResponse(DevicePortal.MachineNameApi, HttpOperations.Get);
+            TestHelpers.MockHttpResponder.AddMockResponse(DevicePortal.MachineNameApi, HttpMethods.Get);
 
             Task<string> getNameTask = TestHelpers.Portal.GetDeviceName();
             getNameTask.Wait();

--- a/WindowsDevicePortalWrapper/UnitTestProject/Core/PerformanceDataTests.cs
+++ b/WindowsDevicePortalWrapper/UnitTestProject/Core/PerformanceDataTests.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Tools.WindowsDevicePortal.Tests.Core
         [TestMethod]
         public void GetRunningProcessesTest()
         {
-            TestHelpers.MockHttpResponder.AddMockResponse(DevicePortal.RunningProcessApi, HttpOperations.Get);
+            TestHelpers.MockHttpResponder.AddMockResponse(DevicePortal.RunningProcessApi, HttpMethods.Get);
 
             Task<RunningProcesses> getRunningProcessesTask = TestHelpers.Portal.GetRunningProcesses();
             getRunningProcessesTask.Wait();
@@ -40,7 +40,7 @@ namespace Microsoft.Tools.WindowsDevicePortal.Tests.Core
         [TestMethod]
         public void GetRunningProcessesWebSocketTest()
         {
-            TestHelpers.MockHttpResponder.AddMockResponse(DevicePortal.RunningProcessApi, HttpOperations.WebSocket);
+            TestHelpers.MockHttpResponder.AddMockResponse(DevicePortal.RunningProcessApi, HttpMethods.WebSocket);
 
             ManualResetEvent runningProcessesReceived = new ManualResetEvent(false);
             RunningProcesses runningProcesses = null;
@@ -78,7 +78,7 @@ namespace Microsoft.Tools.WindowsDevicePortal.Tests.Core
         [TestMethod]
         public void GetSystemPerfTest()
         {
-            TestHelpers.MockHttpResponder.AddMockResponse(DevicePortal.SystemPerfApi, HttpOperations.Get);
+            TestHelpers.MockHttpResponder.AddMockResponse(DevicePortal.SystemPerfApi, HttpMethods.Get);
 
             Task<SystemPerformanceInformation> getSystemPerfTask = TestHelpers.Portal.GetSystemPerf();
             getSystemPerfTask.Wait();
@@ -94,7 +94,7 @@ namespace Microsoft.Tools.WindowsDevicePortal.Tests.Core
         [TestMethod]
         public void GetSystemPerfWebSocketTest()
         {
-            TestHelpers.MockHttpResponder.AddMockResponse(DevicePortal.SystemPerfApi, HttpOperations.WebSocket);
+            TestHelpers.MockHttpResponder.AddMockResponse(DevicePortal.SystemPerfApi, HttpMethods.WebSocket);
 
             ManualResetEvent systemPerfReceived = new ManualResetEvent(false);
             SystemPerformanceInformation systemPerfInfo = null;

--- a/WindowsDevicePortalWrapper/UnitTestProject/Device-VersionTests/XboxOne/XboxHelpers.cs
+++ b/WindowsDevicePortalWrapper/UnitTestProject/Device-VersionTests/XboxOne/XboxHelpers.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Tools.WindowsDevicePortal.Tests
         /// <param name="operatingSystemVersion">The version of the OS we are targeting.</param>
         public static void VerifyOsInformation(string operatingSystemVersion)
         {
-            TestHelpers.MockHttpResponder.AddMockResponse(DevicePortal.MachineNameApi, DevicePortalPlatforms.XboxOne, operatingSystemVersion, HttpOperations.Get);
+            TestHelpers.MockHttpResponder.AddMockResponse(DevicePortal.MachineNameApi, DevicePortalPlatforms.XboxOne, operatingSystemVersion, HttpMethods.Get);
 
             Task<string> getNameTask = TestHelpers.Portal.GetDeviceName();
             getNameTask.Wait();

--- a/WindowsDevicePortalWrapper/UnitTestProject/Device-VersionTests/XboxOne/XboxOne_14385_1002_amd64fre_rs1_xbox_rel_1608_160709_1700.cs
+++ b/WindowsDevicePortalWrapper/UnitTestProject/Device-VersionTests/XboxOne/XboxOne_14385_1002_amd64fre_rs1_xbox_rel_1608_160709_1700.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Tools.WindowsDevicePortal.Tests
         [TestMethod]
         public void GetXboxLiveUserListTest_XboxOne_1608()
         {
-            TestHelpers.MockHttpResponder.AddMockResponse(DevicePortal.XboxLiveUserApi, this.PlatformType, this.OperatingSystemVersion, HttpOperations.Get);
+            TestHelpers.MockHttpResponder.AddMockResponse(DevicePortal.XboxLiveUserApi, this.PlatformType, this.OperatingSystemVersion, HttpMethods.Get);
 
             Task<UserList> getUserTask = TestHelpers.Portal.GetXboxLiveUsers();
             getUserTask.Wait();
@@ -85,7 +85,7 @@ namespace Microsoft.Tools.WindowsDevicePortal.Tests
         [TestMethod]
         public void GetXboxSettingsTest_XboxOne_1608()
         {
-            TestHelpers.MockHttpResponder.AddMockResponse(DevicePortal.XboxSettingsApi, this.PlatformType, this.OperatingSystemVersion, HttpOperations.Get);
+            TestHelpers.MockHttpResponder.AddMockResponse(DevicePortal.XboxSettingsApi, this.PlatformType, this.OperatingSystemVersion, HttpMethods.Get);
 
             Task<XboxSettingList> getSettingsTask = TestHelpers.Portal.GetXboxSettings();
             getSettingsTask.Wait();
@@ -120,7 +120,7 @@ namespace Microsoft.Tools.WindowsDevicePortal.Tests
         [TestMethod]
         public void AppFileExplorerGetKnownFolderTest_XboxOne_1608()
         {
-            TestHelpers.MockHttpResponder.AddMockResponse(DevicePortal.KnownFoldersApi, this.PlatformType, this.OperatingSystemVersion, HttpOperations.Get);
+            TestHelpers.MockHttpResponder.AddMockResponse(DevicePortal.KnownFoldersApi, this.PlatformType, this.OperatingSystemVersion, HttpMethods.Get);
 
             Task<KnownFolders> getKnownFoldersTask = TestHelpers.Portal.GetKnownFolders();
             getKnownFoldersTask.Wait();
@@ -142,7 +142,7 @@ namespace Microsoft.Tools.WindowsDevicePortal.Tests
         [TestMethod]
         public void AppFileExplorerGetFolderContentsTest_XboxOne_1608()
         {
-            TestHelpers.MockHttpResponder.AddMockResponse(DevicePortal.GetFilesApi, this.PlatformType, this.OperatingSystemVersion, HttpOperations.Get);
+            TestHelpers.MockHttpResponder.AddMockResponse(DevicePortal.GetFilesApi, this.PlatformType, this.OperatingSystemVersion, HttpMethods.Get);
 
             Task<FolderContents> getFolderContentsTask = TestHelpers.Portal.GetFolderContents("DevelopmentFiles");
             getFolderContentsTask.Wait();
@@ -245,7 +245,7 @@ namespace Microsoft.Tools.WindowsDevicePortal.Tests
         [TestMethod]
         public void GetRunningProcessesTest_XboxOne_1608()
         {
-            TestHelpers.MockHttpResponder.AddMockResponse(DevicePortal.RunningProcessApi, this.PlatformType, this.OperatingSystemVersion, HttpOperations.Get);
+            TestHelpers.MockHttpResponder.AddMockResponse(DevicePortal.RunningProcessApi, this.PlatformType, this.OperatingSystemVersion, HttpMethods.Get);
 
             Task<RunningProcesses> getRunningProcessesTask = TestHelpers.Portal.GetRunningProcesses();
             getRunningProcessesTask.Wait();
@@ -262,7 +262,7 @@ namespace Microsoft.Tools.WindowsDevicePortal.Tests
         [TestMethod]
         public void GetRunningProcessesWebSocketTest_XboxOne_1608()
         {
-            TestHelpers.MockHttpResponder.AddMockResponse(DevicePortal.RunningProcessApi, this.PlatformType, this.OperatingSystemVersion, HttpOperations.WebSocket);
+            TestHelpers.MockHttpResponder.AddMockResponse(DevicePortal.RunningProcessApi, this.PlatformType, this.OperatingSystemVersion, HttpMethods.WebSocket);
 
             ManualResetEvent runningProcessesReceived = new ManualResetEvent(false);
             RunningProcesses runningProcesses = null;
@@ -302,7 +302,7 @@ namespace Microsoft.Tools.WindowsDevicePortal.Tests
         [TestMethod]
         public void GetSystemPerfTest_XboxOne_1608()
         {
-            TestHelpers.MockHttpResponder.AddMockResponse(DevicePortal.SystemPerfApi, this.PlatformType, this.OperatingSystemVersion, HttpOperations.Get);
+            TestHelpers.MockHttpResponder.AddMockResponse(DevicePortal.SystemPerfApi, this.PlatformType, this.OperatingSystemVersion, HttpMethods.Get);
 
             Task<SystemPerformanceInformation> getSystemPerfTask = TestHelpers.Portal.GetSystemPerf();
             getSystemPerfTask.Wait();
@@ -319,7 +319,7 @@ namespace Microsoft.Tools.WindowsDevicePortal.Tests
         [TestMethod]
         public void GetSystemPerfWebSocketTest_XboxOne_1608()
         {
-            TestHelpers.MockHttpResponder.AddMockResponse(DevicePortal.SystemPerfApi, this.PlatformType, this.OperatingSystemVersion, HttpOperations.WebSocket);
+            TestHelpers.MockHttpResponder.AddMockResponse(DevicePortal.SystemPerfApi, this.PlatformType, this.OperatingSystemVersion, HttpMethods.WebSocket);
 
             ManualResetEvent systemPerfReceived = new ManualResetEvent(false);
             SystemPerformanceInformation systemPerfInfo = null;

--- a/WindowsDevicePortalWrapper/UnitTestProject/MockHttpResponder.cs
+++ b/WindowsDevicePortalWrapper/UnitTestProject/MockHttpResponder.cs
@@ -38,12 +38,12 @@ namespace Microsoft.Tools.WindowsDevicePortal.Tests
         /// </summary>
         /// <param name="endpoint">The endpoint to be mocked.</param>
         /// <param name="response">The response to return.</param>
-        /// <param name="httpOperation">HTTP operation we are mocking.</param>
-        public void AddMockResponse(string endpoint, HttpResponseMessage response, HttpOperations httpOperation)
+        /// <param name="httpMethod">HTTP method we are mocking.</param>
+        public void AddMockResponse(string endpoint, HttpResponseMessage response, HttpMethods httpMethod)
         {
-            if (httpOperation != HttpOperations.Get)
+            if (httpMethod != HttpMethods.Get)
             {
-                endpoint = httpOperation.ToString() + "_" + endpoint;
+                endpoint = httpMethod.ToString() + "_" + endpoint;
             }
 
             Utilities.ModifyEndpointForFilename(ref endpoint);
@@ -57,19 +57,19 @@ namespace Microsoft.Tools.WindowsDevicePortal.Tests
         /// <param name="endpoint">Endpoint we are mocking.</param>
         /// <param name="platform">Device platform we are testing.</param>
         /// <param name="operatingSystemVersion">The OS Version we are testing.</param>
-        /// <param name="httpOperation">HTTP operation we are mocking.</param>
-        public void AddMockResponse(string endpoint, DevicePortalPlatforms platform, string operatingSystemVersion, HttpOperations httpOperation)
+        /// <param name="httpMethod">HTTP method we are mocking.</param>
+        public void AddMockResponse(string endpoint, DevicePortalPlatforms platform, string operatingSystemVersion, HttpMethods httpMethod)
         {
             // If no OS is provided, use the default.
             if (operatingSystemVersion == null)
             {
-                this.AddMockResponse(endpoint, httpOperation);
+                this.AddMockResponse(endpoint, httpMethod);
                 return;
             }
 
-            if (httpOperation != HttpOperations.Get)
+            if (httpMethod != HttpMethods.Get)
             {
-                endpoint = httpOperation.ToString() + "_" + endpoint;
+                endpoint = httpMethod.ToString() + "_" + endpoint;
             }
 
             Utilities.ModifyEndpointForFilename(ref endpoint);
@@ -85,14 +85,14 @@ namespace Microsoft.Tools.WindowsDevicePortal.Tests
         /// Adds a default response for this endpoint, device agnostic.
         /// </summary>
         /// <param name="endpoint">Endpoint we are mocking.</param>
-        /// <param name="httpOperation">HTTP operation we are mocking.</param>
-        public void AddMockResponse(string endpoint, HttpOperations httpOperation)
+        /// <param name="httpMethod">HTTP method we are mocking.</param>
+        public void AddMockResponse(string endpoint, HttpMethods httpMethod)
         {
             HttpResponseMessage response = new HttpResponseMessage(HttpStatusCode.OK);
 
-            if (httpOperation != HttpOperations.Get)
+            if (httpMethod != HttpMethods.Get)
             {
-                endpoint = httpOperation.ToString() + "_" + endpoint;
+                endpoint = httpMethod.ToString() + "_" + endpoint;
             }
 
             Utilities.ModifyEndpointForFilename(ref endpoint);
@@ -112,7 +112,7 @@ namespace Microsoft.Tools.WindowsDevicePortal.Tests
         /// <returns>Async task returning the response.</returns>
         public async Task<HttpResponseMessage> GetAsync(Uri uri)
         {
-            Task<HttpResponseMessage> task = new Task<HttpResponseMessage>(() => this.HttpStoredResponse(uri, HttpOperations.Get));
+            Task<HttpResponseMessage> task = new Task<HttpResponseMessage>(() => this.HttpStoredResponse(uri, HttpMethods.Get));
             task.Start();
 
             return await task;
@@ -126,7 +126,7 @@ namespace Microsoft.Tools.WindowsDevicePortal.Tests
         /// <returns>Async task returning the response.</returns>
         public async Task<HttpResponseMessage> PostAsync(Uri uri, HttpContent content)
         {
-            Task<HttpResponseMessage> task = new Task<HttpResponseMessage>(() => this.HttpStoredResponse(uri, HttpOperations.Post));
+            Task<HttpResponseMessage> task = new Task<HttpResponseMessage>(() => this.HttpStoredResponse(uri, HttpMethods.Post));
             task.Start();
 
             return await task;
@@ -140,7 +140,7 @@ namespace Microsoft.Tools.WindowsDevicePortal.Tests
         /// <returns>Async task returning the response.</returns>
         public async Task<HttpResponseMessage> PutAsync(Uri uri, HttpContent content)
         {
-            Task<HttpResponseMessage> task = new Task<HttpResponseMessage>(() => this.HttpStoredResponse(uri, HttpOperations.Put));
+            Task<HttpResponseMessage> task = new Task<HttpResponseMessage>(() => this.HttpStoredResponse(uri, HttpMethods.Put));
             task.Start();
 
             return await task;
@@ -154,7 +154,7 @@ namespace Microsoft.Tools.WindowsDevicePortal.Tests
         public async Task<HttpResponseMessage> DeleteAsync(Uri uri)
         {
             // Task<HttpResponseMessage> task = new Task<HttpResponseMessage>(this.HttpStoredResponse, uri);
-            Task<HttpResponseMessage> task = new Task<HttpResponseMessage>(() => this.HttpStoredResponse(uri, HttpOperations.Delete));
+            Task<HttpResponseMessage> task = new Task<HttpResponseMessage>(() => this.HttpStoredResponse(uri, HttpMethods.Delete));
             task.Start();
 
             return await task;
@@ -167,7 +167,7 @@ namespace Microsoft.Tools.WindowsDevicePortal.Tests
         /// <returns>Async task returning the response.</returns>
         public async Task<HttpResponseMessage> WebSocketAsync(Uri uri)
         {
-            Task<HttpResponseMessage> task = new Task<HttpResponseMessage>(() => this.HttpStoredResponse(uri, HttpOperations.WebSocket));
+            Task<HttpResponseMessage> task = new Task<HttpResponseMessage>(() => this.HttpStoredResponse(uri, HttpMethods.WebSocket));
             task.Start();
 
             return await task;
@@ -179,7 +179,7 @@ namespace Microsoft.Tools.WindowsDevicePortal.Tests
         /// <param name="uri">The URI we are looking for a canned response for.</param>
         /// <param name="httpOperation">The httpOperation we are looking for a canned response for.</param>
         /// <returns>An HttpResponseMessage previously stored for this URI.</returns>
-        private HttpResponseMessage HttpStoredResponse(Uri uri, HttpOperations httpOperation)
+        private HttpResponseMessage HttpStoredResponse(Uri uri, HttpMethods httpOperation)
         {
             Assert.IsNotNull(uri);
 
@@ -190,7 +190,7 @@ namespace Microsoft.Tools.WindowsDevicePortal.Tests
                 targetEndpoint = targetEndpoint.Remove(0, 1);
             }
 
-            if (httpOperation != HttpOperations.Get)
+            if (httpOperation != HttpMethods.Get)
             {
                 targetEndpoint = httpOperation.ToString() + "_" + targetEndpoint;
             }

--- a/WindowsDevicePortalWrapper/UnitTestProject/TestHelpers.cs
+++ b/WindowsDevicePortalWrapper/UnitTestProject/TestHelpers.cs
@@ -34,8 +34,8 @@ namespace Microsoft.Tools.WindowsDevicePortal.Tests
         public static void EstablishMockConnection(DevicePortalPlatforms platform, string operatingSystemVersion)
         {
             TestHelpers.MockHttpResponder = new MockHttpResponder();
-            TestHelpers.MockHttpResponder.AddMockResponse(DevicePortal.DeviceFamilyApi, platform, operatingSystemVersion, HttpOperations.Get);
-            TestHelpers.MockHttpResponder.AddMockResponse(DevicePortal.OsInfoApi, platform, operatingSystemVersion, HttpOperations.Get);
+            TestHelpers.MockHttpResponder.AddMockResponse(DevicePortal.DeviceFamilyApi, platform, operatingSystemVersion, HttpMethods.Get);
+            TestHelpers.MockHttpResponder.AddMockResponse(DevicePortal.OsInfoApi, platform, operatingSystemVersion, HttpMethods.Get);
 
             TestHelpers.Portal = new DevicePortal(new MockDevicePortalConnection());
 

--- a/WindowsDevicePortalWrapper/UnitTestProject/WDPMockImplementations/AppDeployment.cs
+++ b/WindowsDevicePortalWrapper/UnitTestProject/WDPMockImplementations/AppDeployment.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Tools.WindowsDevicePortal
 
             using (HttpClient client = new HttpClient(handler))
             {
-                this.ApplyHttpHeaders(client, "GET");
+                this.ApplyHttpHeaders(client, HttpMethods.Get);
 
                 Task<HttpResponseMessage> getTask = TestHelpers.MockHttpResponder.GetAsync(uri);
                 await getTask.ConfigureAwait(false);

--- a/WindowsDevicePortalWrapper/UnitTestProject/WDPMockImplementations/RestDelete.cs
+++ b/WindowsDevicePortalWrapper/UnitTestProject/WDPMockImplementations/RestDelete.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Tools.WindowsDevicePortal
 
             using (HttpClient client = new HttpClient(requestSettings))
             {
-                this.ApplyHttpHeaders(client, "DELETE");
+                this.ApplyHttpHeaders(client, HttpMethods.Delete);
 
                 Task<HttpResponseMessage> deleteTask = TestHelpers.MockHttpResponder.DeleteAsync(uri);
                 await deleteTask.ConfigureAwait(false);

--- a/WindowsDevicePortalWrapper/UnitTestProject/WDPMockImplementations/RestGet.cs
+++ b/WindowsDevicePortalWrapper/UnitTestProject/WDPMockImplementations/RestGet.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Tools.WindowsDevicePortal
 
             using (HttpClient client = new HttpClient(handler))
             {
-                this.ApplyHttpHeaders(client, "GET");
+                this.ApplyHttpHeaders(client, HttpMethods.Get);
 
                 Task<HttpResponseMessage> getTask = TestHelpers.MockHttpResponder.GetAsync(uri);
                 await getTask.ConfigureAwait(false);

--- a/WindowsDevicePortalWrapper/UnitTestProject/WDPMockImplementations/RestPost.cs
+++ b/WindowsDevicePortalWrapper/UnitTestProject/WDPMockImplementations/RestPost.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Tools.WindowsDevicePortal
 
             using (HttpClient client = new HttpClient(requestSettings))
             {
-                this.ApplyHttpHeaders(client, "POST");
+                this.ApplyHttpHeaders(client, HttpMethods.Post);
 
                 Task<HttpResponseMessage> postTask = TestHelpers.MockHttpResponder.PostAsync(uri, requestContent);
                 await postTask.ConfigureAwait(false);

--- a/WindowsDevicePortalWrapper/UnitTestProject/WDPMockImplementations/RestPut.cs
+++ b/WindowsDevicePortalWrapper/UnitTestProject/WDPMockImplementations/RestPut.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Tools.WindowsDevicePortal
 
             using (HttpClient client = new HttpClient(requestSettings))
             {
-                this.ApplyHttpHeaders(client, "PUT");
+                this.ApplyHttpHeaders(client, HttpMethods.Put);
 
                 // Send the request
                 Task<HttpResponseMessage> putTask = TestHelpers.MockHttpResponder.PutAsync(uri, body);

--- a/WindowsDevicePortalWrapper/UnitTestProject/Xbox/UserManagementTests.cs
+++ b/WindowsDevicePortalWrapper/UnitTestProject/Xbox/UserManagementTests.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Tools.WindowsDevicePortal.Tests
         [TestMethod]
         public void GetXboxLiveUserListTest()
         {
-            TestHelpers.MockHttpResponder.AddMockResponse(DevicePortal.XboxLiveUserApi, HttpOperations.Get);
+            TestHelpers.MockHttpResponder.AddMockResponse(DevicePortal.XboxLiveUserApi, HttpMethods.Get);
 
             Task<UserList> getUserTask = TestHelpers.Portal.GetXboxLiveUsers();
             getUserTask.Wait();
@@ -63,7 +63,7 @@ namespace Microsoft.Tools.WindowsDevicePortal.Tests
         public void UpdateXboxLiveUsersTest()
         {
             HttpResponseMessage response = new HttpResponseMessage(HttpStatusCode.NoContent);
-            TestHelpers.MockHttpResponder.AddMockResponse(DevicePortal.XboxLiveUserApi, response, HttpOperations.Put);
+            TestHelpers.MockHttpResponder.AddMockResponse(DevicePortal.XboxLiveUserApi, response, HttpMethods.Put);
 
             UserList users = new UserList();
             UserInfo user = new UserInfo();
@@ -93,7 +93,7 @@ namespace Microsoft.Tools.WindowsDevicePortal.Tests
 
             response.Content = content;
 
-            TestHelpers.MockHttpResponder.AddMockResponse(DevicePortal.XboxLiveUserApi, response, HttpOperations.Put);
+            TestHelpers.MockHttpResponder.AddMockResponse(DevicePortal.XboxLiveUserApi, response, HttpMethods.Put);
 
             UserList users = new UserList();
             UserInfo user = new UserInfo();

--- a/WindowsDevicePortalWrapper/UnitTestProject/Xbox/XboxAppDeploymentTests.cs
+++ b/WindowsDevicePortalWrapper/UnitTestProject/Xbox/XboxAppDeploymentTests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Tools.WindowsDevicePortal.Tests
         [TestMethod]
         public void XboxAppDeploymentTest()
         {
-            TestHelpers.MockHttpResponder.AddMockResponse(DevicePortal.RegisterPackageApi, HttpOperations.Post);
+            TestHelpers.MockHttpResponder.AddMockResponse(DevicePortal.RegisterPackageApi, HttpMethods.Post);
 
             Task registerTask = TestHelpers.Portal.RegisterApplication("SomeLooseFolder");
             registerTask.Wait();

--- a/WindowsDevicePortalWrapper/UnitTestProject/Xbox/XboxSettingsTests.cs
+++ b/WindowsDevicePortalWrapper/UnitTestProject/Xbox/XboxSettingsTests.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Tools.WindowsDevicePortal.Tests
         [TestMethod]
         public void GetXboxSettingsTest()
         {
-            TestHelpers.MockHttpResponder.AddMockResponse(DevicePortal.XboxSettingsApi, HttpOperations.Get);
+            TestHelpers.MockHttpResponder.AddMockResponse(DevicePortal.XboxSettingsApi, HttpMethods.Get);
 
             Task<XboxSettingList> getSettingsTask = TestHelpers.Portal.GetXboxSettings();
             getSettingsTask.Wait();
@@ -64,7 +64,7 @@ namespace Microsoft.Tools.WindowsDevicePortal.Tests
         public void GetSingleXboxSettingTest()
         {
             string settingName = "TVResolution";
-            TestHelpers.MockHttpResponder.AddMockResponse(Path.Combine(DevicePortal.XboxSettingsApi, settingName), HttpOperations.Get);
+            TestHelpers.MockHttpResponder.AddMockResponse(Path.Combine(DevicePortal.XboxSettingsApi, settingName), HttpMethods.Get);
 
             Task<XboxSetting> getSettingTask = TestHelpers.Portal.GetXboxSetting(settingName);
             getSettingTask.Wait();
@@ -92,7 +92,7 @@ namespace Microsoft.Tools.WindowsDevicePortal.Tests
             setting.Value = "1080p";
 
             HttpResponseMessage response = new HttpResponseMessage(HttpStatusCode.NoContent);
-            TestHelpers.MockHttpResponder.AddMockResponse(Path.Combine(DevicePortal.XboxSettingsApi, setting.Name), HttpOperations.Put);
+            TestHelpers.MockHttpResponder.AddMockResponse(Path.Combine(DevicePortal.XboxSettingsApi, setting.Name), HttpMethods.Put);
 
             Task<XboxSetting> updateSettingsTask = TestHelpers.Portal.UpdateXboxSetting(setting);
             updateSettingsTask.Wait();

--- a/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper.Shared/DevicePortal.cs
+++ b/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper.Shared/DevicePortal.cs
@@ -47,32 +47,32 @@ namespace Microsoft.Tools.WindowsDevicePortal
         }
 
         /// <summary>
-        /// HTTP Operations
+        /// HTTP Methods
         /// </summary>
-        public enum HttpOperations
+        public enum HttpMethods
         {
             /// <summary>
-            /// The HTTP Get operation.
+            /// The HTTP Get method.
             /// </summary>
             Get,
 
             /// <summary>
-            /// The HTTP Put operation.
+            /// The HTTP Put method.
             /// </summary>
             Put,
 
             /// <summary>
-            /// The HTTP Post operation.
+            /// The HTTP Post method.
             /// </summary>
             Post,
 
             /// <summary>
-            /// The HTTP Delete operation.
+            /// The HTTP Delete method.
             /// </summary>
             Delete,
 
             /// <summary>
-            /// The HTTP WebSocket operation.
+            /// The HTTP WebSocket method.
             /// </summary>
             WebSocket
         }
@@ -278,9 +278,9 @@ namespace Microsoft.Tools.WindowsDevicePortal
         /// </summary>
         /// <param name="endpoint">API endpoint we are calling.</param>
         /// <param name="directory">Directory to store our file.</param>
-        /// <param name="httpOperation">The http operation to be performed.</param>
+        /// <param name="httpMethod">The http method to be performed.</param>
         /// <returns>Task waiting for HTTP call to return and file copy to complete.</returns>
-        public async Task SaveEndpointResponseToFile(string endpoint, string directory, HttpOperations httpOperation)
+        public async Task SaveEndpointResponseToFile(string endpoint, string directory, HttpMethods httpMethod)
         {
             Uri uri = new Uri(this.deviceConnection.Connection, endpoint);
 
@@ -288,9 +288,9 @@ namespace Microsoft.Tools.WindowsDevicePortal
             // we can create a class with the same name as this Device/OS pair for tests.
             string filename = endpoint + "_" + this.Platform.ToString() + "_" + this.OperatingSystemVersion;
 
-            if (httpOperation != HttpOperations.Get)
+            if (httpMethod != HttpMethods.Get)
             {
-                filename = httpOperation.ToString() + "_" + filename;
+                filename = httpMethod.ToString() + "_" + filename;
             }
 
             Utilities.ModifyEndpointForFilename(ref filename);
@@ -298,7 +298,7 @@ namespace Microsoft.Tools.WindowsDevicePortal
             filename += ".dat";
             string filepath = Path.Combine(directory, filename);
 
-            if (HttpOperations.WebSocket == httpOperation)
+            if (HttpMethods.WebSocket == httpMethod)
             {
 #if WINDOWS_UWP
                 WebSocket<object> websocket = new WebSocket<object>(this.deviceConnection, true);

--- a/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper.Shared/HttpRest/HttpHeadersHelper.cs
+++ b/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper.Shared/HttpRest/HttpHeadersHelper.cs
@@ -56,12 +56,12 @@ namespace Microsoft.Tools.WindowsDevicePortal
         /// <param name="method">The HTTP method (ex: POST) that will be called on the client.</param>
         public void ApplyCSRFHeader(
             HttpClient client, 
-            string method)
+            HttpMethods method)
         {
             string headerName = "X-" + CsrfTokenName;
             string headerValue = this.csrfToken;
 
-            if (string.Compare(method, "get", true) == 0)
+            if (string.Compare(method.ToString(), "get", true) == 0)
             {
                 headerName = CsrfTokenName;
                 headerValue = string.IsNullOrEmpty(this.csrfToken) ? "Fetch" : headerValue;
@@ -83,7 +83,7 @@ namespace Microsoft.Tools.WindowsDevicePortal
         /// <param name="method">The HTTP method (ex: POST) that will be called on the client.</param>
         public void ApplyHttpHeaders(
             HttpClient client,
-            string method)
+            HttpMethods method)
         {
             this.ApplyCSRFHeader(client, method);
             this.ApplyUserAgentHeader(client);

--- a/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper.UniversalWindows/CertificateHandling.cs
+++ b/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper.UniversalWindows/CertificateHandling.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Tools.WindowsDevicePortal
 
                     using (HttpClient client = new HttpClient(requestSettings))
                     {
-                        this.ApplyHttpHeaders(client, "GET");
+                        this.ApplyHttpHeaders(client, HttpMethods.Get);
 
                         IAsyncOperationWithProgress<HttpResponseMessage, HttpProgress> responseOperation = client.GetAsync(uri);
                         TaskAwaiter<HttpResponseMessage> responseAwaiter = responseOperation.GetAwaiter();

--- a/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper.UniversalWindows/Core/AppDeployment.cs
+++ b/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper.UniversalWindows/Core/AppDeployment.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Tools.WindowsDevicePortal
 
             using (HttpClient client = new HttpClient(httpFilter))
             {
-                this.ApplyHttpHeaders(client, "GET");
+                this.ApplyHttpHeaders(client, HttpMethods.Get);
 
                 IAsyncOperationWithProgress<HttpResponseMessage, HttpProgress> responseOperation = client.GetAsync(uri);
                 while (responseOperation.Status != AsyncStatus.Completed)

--- a/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper.UniversalWindows/HttpRest/RestDelete.cs
+++ b/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper.UniversalWindows/HttpRest/RestDelete.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Tools.WindowsDevicePortal
 
             using (HttpClient client = new HttpClient(httpFilter))
             {
-                this.ApplyHttpHeaders(client, "DELETE");
+                this.ApplyHttpHeaders(client, HttpMethods.Delete);
 
                 IAsyncOperationWithProgress<HttpResponseMessage, HttpProgress> responseOperation = client.DeleteAsync(uri);
                 TaskAwaiter<HttpResponseMessage> responseAwaiter = responseOperation.GetAwaiter();

--- a/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper.UniversalWindows/HttpRest/RestGet.cs
+++ b/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper.UniversalWindows/HttpRest/RestGet.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Tools.WindowsDevicePortal
 
             using (HttpClient client = new HttpClient(requestSettings))
             {
-                this.ApplyHttpHeaders(client, "GET");
+                this.ApplyHttpHeaders(client, HttpMethods.Get);
 
                 IAsyncOperationWithProgress<HttpResponseMessage, HttpProgress> responseOperation = client.GetAsync(uri);
                 TaskAwaiter<HttpResponseMessage> responseAwaiter = responseOperation.GetAwaiter();

--- a/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper.UniversalWindows/HttpRest/RestPost.cs
+++ b/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper.UniversalWindows/HttpRest/RestPost.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Tools.WindowsDevicePortal
 
             using (HttpClient client = new HttpClient(httpFilter))
             {
-                this.ApplyHttpHeaders(client, "POST");
+                this.ApplyHttpHeaders(client, HttpMethods.Post);
 
                 IAsyncOperationWithProgress<HttpResponseMessage, HttpProgress> responseOperation = client.PostAsync(uri, requestContent);
                 TaskAwaiter<HttpResponseMessage> responseAwaiter = responseOperation.GetAwaiter();

--- a/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper.UniversalWindows/HttpRest/RestPut.cs
+++ b/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper.UniversalWindows/HttpRest/RestPut.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Tools.WindowsDevicePortal
 
             using (HttpClient client = new HttpClient(httpFilter))
             {
-                this.ApplyHttpHeaders(client, "PUT");
+                this.ApplyHttpHeaders(client, HttpMethods.Put);
 
                 // Send the request
                 IAsyncOperationWithProgress<HttpResponseMessage, HttpProgress> responseOperation = client.PutAsync(uri, null);

--- a/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper/Core/AppDeployment.cs
+++ b/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper/Core/AppDeployment.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Tools.WindowsDevicePortal
 
             using (HttpClient client = new HttpClient(handler))
             {
-                this.ApplyHttpHeaders(client, "GET");
+                this.ApplyHttpHeaders(client, HttpMethods.Get);
 
                 Task<HttpResponseMessage> getTask = client.GetAsync(uri);
                 await getTask.ConfigureAwait(false);

--- a/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper/HttpRest/RestDelete.cs
+++ b/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper/HttpRest/RestDelete.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Tools.WindowsDevicePortal
 
             using (HttpClient client = new HttpClient(requestSettings))
             {
-                this.ApplyHttpHeaders(client, "DELETE");
+                this.ApplyHttpHeaders(client, HttpMethods.Delete);
 
                 Task<HttpResponseMessage> deleteTask = client.DeleteAsync(uri);
                 await deleteTask.ConfigureAwait(false);

--- a/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper/HttpRest/RestGet.cs
+++ b/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper/HttpRest/RestGet.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Tools.WindowsDevicePortal
 
             using (HttpClient client = new HttpClient(handler))
             {
-                this.ApplyHttpHeaders(client, "GET");
+                this.ApplyHttpHeaders(client, HttpMethods.Get);
 
                 Task<HttpResponseMessage> getTask = client.GetAsync(uri);
                 await getTask.ConfigureAwait(false);

--- a/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper/HttpRest/RestPost.cs
+++ b/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper/HttpRest/RestPost.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Tools.WindowsDevicePortal
 
             using (HttpClient client = new HttpClient(requestSettings))
             {
-                this.ApplyHttpHeaders(client, "POST");
+                this.ApplyHttpHeaders(client, HttpMethods.Post);
 
                 Task<HttpResponseMessage> postTask = client.PostAsync(uri, requestContent);
                 await postTask.ConfigureAwait(false);

--- a/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper/HttpRest/RestPut.cs
+++ b/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper/HttpRest/RestPut.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Tools.WindowsDevicePortal
 
             using (HttpClient client = new HttpClient(requestSettings))
             {
-                this.ApplyHttpHeaders(client, "PUT");
+                this.ApplyHttpHeaders(client, HttpMethods.Put);
 
                 // Send the request
                 Task<HttpResponseMessage> putTask = client.PutAsync(uri, body);


### PR DESCRIPTION
Renamed HttpOperations to HttpMethods and have ApplyHttpHeaders use it instead of a string.
