### PR TITLE
add initial HoloLens unit tests, fix bugs in shared code

### DIFF
--- a/WindowsDevicePortalWrapper/MockDataGenerator/Program.cs
+++ b/WindowsDevicePortalWrapper/MockDataGenerator/Program.cs
@@ -41,6 +41,7 @@ namespace MockDataGenerator
             new Endpoint(HttpMethods.Get, DevicePortal.RunningProcessApi),
             new Endpoint(HttpMethods.WebSocket, DevicePortal.SystemPerfApi),
             new Endpoint(HttpMethods.WebSocket, DevicePortal.RunningProcessApi),
+
             // HoloLens specific endpoints
             new Endpoint(HttpMethods.Get, DevicePortal.HolographicIpdApi),
             new Endpoint(HttpMethods.Get, DevicePortal.HolographicServicesApi),
@@ -48,6 +49,7 @@ namespace MockDataGenerator
             new Endpoint(HttpMethods.Get, DevicePortal.MrcFileListApi),
             new Endpoint(HttpMethods.Get, DevicePortal.MrcStatusApi),
             new Endpoint(HttpMethods.Get, DevicePortal.ThermalStageApi),
+
             // Xbox One specific endpoints
             new Endpoint(HttpMethods.Get, DevicePortal.XboxLiveUserApi),
             new Endpoint(HttpMethods.Get, DevicePortal.XboxSettingsApi),

--- a/WindowsDevicePortalWrapper/UnitTestProject/Device-VersionTests/HoloLens/HoloLensHelpers.cs
+++ b/WindowsDevicePortalWrapper/UnitTestProject/Device-VersionTests/HoloLens/HoloLensHelpers.cs
@@ -1,0 +1,41 @@
+﻿//----------------------------------------------------------------------------------------------
+// <copyright file="HoloLensHelpers.cs" company="Microsoft Corporation">
+//     Licensed under the MIT License. See LICENSE.TXT in the project root license information.
+// </copyright>
+//----------------------------------------------------------------------------------------------
+
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using static Microsoft.Tools.WindowsDevicePortal.DevicePortal;
+
+namespace Microsoft.Tools.WindowsDevicePortal.Tests
+{
+    /// <summary>
+    /// Helpers for HoloLens tests.
+    /// </summary>
+    public static class HoloLensHelpers
+    {
+        /// <summary>
+        /// Helper method for verifying OS info based on a given version.
+        /// </summary>
+        /// <param name="friendlyOperatingSystemVersion">The friendly version of the OS we are targeting.</param>
+        /// <param name="operatingSystemVersion">The version of the OS we are targeting.</param>
+        public static void VerifyOsInformation(
+            string friendlyOperatingSystemVersion, 
+            string operatingSystemVersion)
+        {
+            TestHelpers.MockHttpResponder.AddMockResponse(
+                DevicePortal.MachineNameApi, 
+                DevicePortalPlatforms.HoloLens, 
+                friendlyOperatingSystemVersion, 
+                HttpMethods.Get);
+
+            Task<string> getNameTask = TestHelpers.Portal.GetDeviceName();
+            getNameTask.Wait();
+
+            Assert.AreEqual(operatingSystemVersion, TestHelpers.Portal.OperatingSystemVersion);
+            Assert.AreEqual(DevicePortalPlatforms.HoloLens, TestHelpers.Portal.Platform);
+            Assert.AreEqual("MyHoloLens", getNameTask.Result);
+        }
+    }
+}

--- a/WindowsDevicePortalWrapper/UnitTestProject/Device-VersionTests/HoloLens/HoloLens_rs1_release.cs
+++ b/WindowsDevicePortalWrapper/UnitTestProject/Device-VersionTests/HoloLens/HoloLens_rs1_release.cs
@@ -1,0 +1,228 @@
+﻿//----------------------------------------------------------------------------------------------
+// <copyright file="HoloLens_rs1_release.cs" company="Microsoft Corporation">
+//     Licensed under the MIT License. See LICENSE.TXT in the project root license information.
+// </copyright>
+//----------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using static Microsoft.Tools.WindowsDevicePortal.DevicePortal;
+
+namespace Microsoft.Tools.WindowsDevicePortal.Tests
+{
+    /// <summary>
+    /// Test class for HoloLens_rs1_release version
+    /// </summary>
+    [TestClass]
+    public class HoloLens_rs1_release : BaseTests
+    {
+        /// <summary>
+        /// Gets the Platform type these tests are targeting.
+        /// </summary>
+        protected override DevicePortalPlatforms PlatformType
+        {
+            get
+            {
+                return DevicePortalPlatforms.HoloLens;
+            }
+        }
+
+        /// <summary>
+        /// Gets the friendly OS Version these tests are targeting.
+        /// </summary>
+        protected override string FriendlyOperatingSystemVersion
+        {
+            get
+            {
+                return "rs1_release";
+            }
+        }
+
+        /// <summary>
+        /// Gets the OS Version these tests are targeting.
+        /// </summary>
+        protected override string OperatingSystemVersion
+        {
+            get
+            {
+                return "14393.0.x86fre.rs1_release.160715-1616";
+            }
+        }
+
+        /// <summary>
+        /// Gets the battery state using a mock generated on a HoloLens.
+        /// </summary>
+        [TestMethod]
+        public void GetBatteryState_HoloLens_1607()
+        {
+            TestHelpers.MockHttpResponder.AddMockResponse(
+                DevicePortal.BatteryStateApi, 
+                this.PlatformType, 
+                this.FriendlyOperatingSystemVersion, 
+                HttpMethods.Get);
+
+            Task<BatteryState> getTask  = TestHelpers.Portal.GetBatteryState();
+            getTask.Wait();
+
+            Assert.AreEqual(TaskStatus.RanToCompletion, getTask.Status);
+
+            // Check some known things about this response.
+            BatteryState batteryState = getTask.Result;
+            Assert.AreEqual(true, batteryState.IsOnAcPower);
+            Assert.AreEqual(true, batteryState.IsBatteryPresent);
+            Assert.AreEqual(4294967295, batteryState.EstimatedTimeRaw);
+            Assert.AreEqual(15079, batteryState.MaximumCapacity);
+            Assert.AreEqual(14921, batteryState.RemainingCapacity);
+        }
+
+        /// <summary>
+        /// Gets the device name using a mock generated on a HoloLens.
+        /// </summary>
+        [TestMethod]
+        public void GetDeviceName_HoloLens_1607()
+        {
+            TestHelpers.MockHttpResponder.AddMockResponse(
+                DevicePortal.MachineNameApi, 
+                this.PlatformType, 
+                this.FriendlyOperatingSystemVersion, 
+                HttpMethods.Get);
+
+            Task<string> getTask  = TestHelpers.Portal.GetDeviceName();
+            getTask.Wait();
+
+            Assert.AreEqual(TaskStatus.RanToCompletion, getTask.Status);
+
+            // Check some known things about this response.
+            Assert.AreEqual("MyHoloLens", getTask.Result);
+        }
+
+        /// <summary>
+        /// Gets the user's interpupilary distance using a mock generated on a HoloLens.
+        /// </summary>
+        [TestMethod]
+        public void GetIpd_HoloLens_1607()
+        {
+            TestHelpers.MockHttpResponder.AddMockResponse(
+                DevicePortal.HolographicIpdApi, 
+                this.PlatformType, 
+                this.FriendlyOperatingSystemVersion, 
+                HttpMethods.Get);
+
+            Task<float> getTask  = TestHelpers.Portal.GetInterPupilaryDistance();
+            getTask.Wait();
+
+            Assert.AreEqual(TaskStatus.RanToCompletion, getTask.Status);
+
+            // Check some known things about this response.
+            Assert.AreEqual(67.5, getTask.Result);
+        }
+
+        /// <summary>
+        /// Gets the list of Mixed Reality Capture files using a mock generated on a HoloLens.
+        /// </summary>
+        [TestMethod]
+        public void GetMrcFileList_HoloLens_1607()
+        {
+            TestHelpers.MockHttpResponder.AddMockResponse(
+                DevicePortal.MrcFileListApi, 
+                this.PlatformType, 
+                this.FriendlyOperatingSystemVersion, 
+                HttpMethods.Get);
+
+            Task<MrcFileList> getTask  = TestHelpers.Portal.GetMrcFileList();
+            getTask.Wait();
+
+            Assert.AreEqual(TaskStatus.RanToCompletion, getTask.Status);
+
+            // Check some known things about this response.
+            MrcFileList fileList = getTask.Result;
+            Assert.AreEqual(4, fileList.Files.Count);
+            Assert.AreEqual(131139576909916579, fileList.Files[1].CreationTimeRaw);
+            Assert.AreEqual("20160725_150130_HoloLens.jpg", fileList.Files[1].FileName);
+            Assert.AreEqual((uint)290929, fileList.Files[1].FileSize);
+       }
+
+        /// <summary>
+        /// Gets the Mixed Reality Capture status using a mock generated on a HoloLens.
+        /// </summary>
+        [TestMethod]
+        public void GetMrcStatus_HoloLens_1607()
+        {
+            TestHelpers.MockHttpResponder.AddMockResponse(
+                DevicePortal.MrcStatusApi, 
+                this.PlatformType, 
+                this.FriendlyOperatingSystemVersion, 
+                HttpMethods.Get);
+
+            Task<MrcStatus> getTask  = TestHelpers.Portal.GetMrcStatus();
+            getTask.Wait();
+
+            Assert.AreEqual(TaskStatus.RanToCompletion, getTask.Status);
+
+            // Check some known things about this response.
+            ProcessStatus processStatus = getTask.Result.Status;
+            Assert.AreEqual("Running", processStatus.MrcProcess);
+        }
+
+        /// <summary>
+        /// Gets the power state using a mock generated on a HoloLens.
+        /// </summary>
+        [TestMethod]
+        public void GetPowerState_HoloLens_1607()
+        {
+            TestHelpers.MockHttpResponder.AddMockResponse(
+                DevicePortal.PowerStateApi, 
+                this.PlatformType, 
+                this.FriendlyOperatingSystemVersion, 
+                HttpMethods.Get);
+
+            Task<PowerState> getTask  = TestHelpers.Portal.GetPowerState();
+            getTask.Wait();
+
+            Assert.AreEqual(TaskStatus.RanToCompletion, getTask.Status);
+
+            // Check some known things about this response.
+            PowerState powerState = getTask.Result;
+            Assert.AreEqual(false, powerState.InLowPowerState);
+            Assert.AreEqual(true, powerState.IsLowPowerStateAvailable);
+        }
+
+        /// <summary>
+        /// Gets the thermal stage using a mock generated on a HoloLens.
+        /// </summary>
+        [TestMethod]
+        public void GetThermalStage_HoloLens_1607()
+        {
+            TestHelpers.MockHttpResponder.AddMockResponse(
+                DevicePortal.ThermalStageApi, 
+                this.PlatformType, 
+                this.FriendlyOperatingSystemVersion, 
+                HttpMethods.Get);
+
+            Task<ThermalStages> getTask  = TestHelpers.Portal.GetThermalStage();
+            getTask.Wait();
+
+            Assert.AreEqual(TaskStatus.RanToCompletion, getTask.Status);
+
+            // Check some known things about this response.
+            Assert.AreEqual(ThermalStages.Normal, getTask.Result);
+        }
+
+        /// <summary>
+        /// Validates the Operating System information using a mock generated on a HoloLens.
+        /// </summary>
+        [TestMethod]
+        public void ValidateOsInfo_HoloLens_1607()
+        {
+            HoloLensHelpers.VerifyOsInformation(
+                this.FriendlyOperatingSystemVersion, 
+                this.OperatingSystemVersion);
+        }
+    }
+}

--- a/WindowsDevicePortalWrapper/UnitTestProject/TestHelpers.cs
+++ b/WindowsDevicePortalWrapper/UnitTestProject/TestHelpers.cs
@@ -36,6 +36,14 @@ namespace Microsoft.Tools.WindowsDevicePortal.Tests
             TestHelpers.MockHttpResponder = new MockHttpResponder();
             TestHelpers.MockHttpResponder.AddMockResponse(DevicePortal.DeviceFamilyApi, platform, operatingSystemVersion, HttpMethods.Get);
             TestHelpers.MockHttpResponder.AddMockResponse(DevicePortal.OsInfoApi, platform, operatingSystemVersion, HttpMethods.Get);
+            if (platform == DevicePortalPlatforms.HoloLens)
+            {
+                TestHelpers.MockHttpResponder.AddMockResponse(
+                    DevicePortal.HolographicWebManagementHttpSettingsApi, 
+                    platform, 
+                    operatingSystemVersion, 
+                    HttpMethods.Get);
+            }
 
             TestHelpers.Portal = new DevicePortal(new MockDevicePortalConnection());
 

--- a/WindowsDevicePortalWrapper/UnitTestProject/UnitTestProject.csproj
+++ b/WindowsDevicePortalWrapper/UnitTestProject/UnitTestProject.csproj
@@ -63,6 +63,8 @@
     <Compile Include="BaseTests.cs" />
     <Compile Include="Core\AppFileExplorerTests.cs" />
     <Compile Include="Core\PerformanceDataTests.cs" />
+    <Compile Include="Device-VersionTests\HoloLens\HoloLensHelpers.cs" />
+    <Compile Include="Device-VersionTests\HoloLens\HoloLens_rs1_release.cs" />
     <Compile Include="Device-VersionTests\XboxOne\XboxHelpers.cs" />
     <Compile Include="Device-VersionTests\XboxOne\XboxOne_rs1_xbox_rel_1608.cs" />
     <Compile Include="MockHttpResponder.cs" />
@@ -113,6 +115,54 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="MockData\Defaults\WebSocket_api_resourcemanager_systemperf_Default.dat">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="MockData\HoloLens\rs1_release\api_holographic_mrc_files_HoloLens_rs1_release.dat">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="MockData\HoloLens\rs1_release\api_holographic_mrc_status_HoloLens_rs1_release.dat">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="MockData\HoloLens\rs1_release\api_holographic_os_services_HoloLens_rs1_release.dat">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="MockData\HoloLens\rs1_release\api_holographic_os_settings_ipd_HoloLens_rs1_release.dat">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="MockData\HoloLens\rs1_release\api_holographic_os_webmanagement_settings_https_HoloLens_rs1_release.dat">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="MockData\HoloLens\rs1_release\api_holographic_thermal_stage_HoloLens_rs1_release.dat">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="MockData\HoloLens\rs1_release\api_networking_ipconfig_HoloLens_rs1_release.dat">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="MockData\HoloLens\rs1_release\api_os_devicefamily_HoloLens_rs1_release.dat">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="MockData\HoloLens\rs1_release\api_os_info_HoloLens_rs1_release.dat">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="MockData\HoloLens\rs1_release\api_os_machinename_HoloLens_rs1_release.dat">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="MockData\HoloLens\rs1_release\api_power_battery_HoloLens_rs1_release.dat">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="MockData\HoloLens\rs1_release\api_power_state_HoloLens_rs1_release.dat">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="MockData\HoloLens\rs1_release\api_resourcemanager_processes_HoloLens_rs1_release.dat">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="MockData\HoloLens\rs1_release\api_resourcemanager_systemperf_HoloLens_rs1_release.dat">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="MockData\HoloLens\rs1_release\WebSocket_api_resourcemanager_processes_HoloLens_rs1_release.dat">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="MockData\HoloLens\rs1_release\WebSocket_api_resourcemanager_systemperf_HoloLens_rs1_release.dat">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="MockData\XboxOne\rs1_xbox_rel_1608\api_filesystem_apps_files_XboxOne_rs1_xbox_rel_1608.dat">

--- a/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper.Shared/Core/Power.cs
+++ b/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper.Shared/Core/Power.cs
@@ -139,7 +139,7 @@ namespace Microsoft.Tools.WindowsDevicePortal
             /// Gets or sets maximum capacity.
             /// </summary>
             [DataMember(Name = "MaximumCapacity")]
-            public uint MaximumCapacity { get; set; }
+            public int MaximumCapacity { get; set; }
 
             /// <summary>
             /// Gets or sets remaining capacity.

--- a/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper.Shared/DevicePortal.cs
+++ b/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper.Shared/DevicePortal.cs
@@ -266,7 +266,7 @@ namespace Microsoft.Tools.WindowsDevicePortal
                 }
                 else
                 {
-                    this.ConnectionHttpStatusCode = (HttpStatusCode)0;
+                    this.ConnectionHttpStatusCode = HttpStatusCode.Conflict;
                 }
 
                 this.SendConnectionStatus(


### PR DESCRIPTION
add unit test cases for HoloLens,

fixed bug where Connect would return a success code if a non-DevicePortalException was caught
fixed bug in BatteryState class definition (MaximumCapacity was typed incorrectly)
