### PR TITLE
Fix CSRF retry logic to not retry with already disposed objects

### DIFF
--- a/Samples/XboxWdpDriver/Program.cs
+++ b/Samples/XboxWdpDriver/Program.cs
@@ -379,6 +379,19 @@ namespace XboxWdpDriver
                     }
                 }
             }
+            catch (AggregateException e)
+            {
+                if (e.InnerException is DevicePortalException)
+                {
+                    DevicePortalException innerException = e.InnerException as DevicePortalException;
+
+                    Console.WriteLine(string.Format("Exception encountered: {0}, hr = 0x{1:X} : {2}", innerException.StatusCode, innerException.HResult, innerException.Reason));
+                }
+                else
+                {
+                    Console.WriteLine(string.Format("Unexpected exception encountered: {0}", e.Message));
+                }
+            }
             catch (Exception e)
             {
                 Console.WriteLine(e.Message);

--- a/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper.Shared/HttpRest/HttpHeadersHelper.cs
+++ b/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper.Shared/HttpRest/HttpHeadersHelper.cs
@@ -152,11 +152,11 @@ namespace Microsoft.Tools.WindowsDevicePortal
         /// <summary>
         /// Checks a response to see if it failed due to a bad CSRF token.
         /// </summary>
-        /// <param name="response">The response from the REST call.</param>
+        /// <param name="exception">The DevicePortalException from the REST call.</param>
         /// <returns>Whether the response failed due to the bad CSRF token.</returns>
-        private bool IsBadCsrfToken(HttpResponseMessage response)
+        private bool IsBadCsrfToken(DevicePortalException exception)
         {
-            return response.StatusCode == HttpStatusCode.Forbidden && response.ReasonPhrase.Equals("CSRF Token Invalid");
+            return exception.StatusCode == HttpStatusCode.Forbidden && exception.Reason.Equals("CSRF Token Invalid");
         }
 
         /// <summary>

--- a/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper.Shared/HttpRest/RestDelete.cs
+++ b/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper.Shared/HttpRest/RestDelete.cs
@@ -37,10 +37,12 @@ namespace Microsoft.Tools.WindowsDevicePortal
         /// <typeparam name="T">The type of the data for the HTTP response body (if present).</typeparam>
         /// <param name="apiPath">The relative portion of the uri path that specifies the API to call.</param>
         /// <param name="payload">The query string portion of the uri path that provides the parameterized data.</param>
+        /// <param name="allowRetry">Allow the Delete to be retried after refreshing the CSRF token.</param>
         /// <returns>Task tracking the HTTP completion.</returns>
         private async Task<T> Delete<T>(
             string apiPath,
-            string payload = null) where T : new()
+            string payload = null,
+            bool allowRetry = true) where T : new()
         {
             T data = default(T);
 
@@ -51,17 +53,35 @@ namespace Microsoft.Tools.WindowsDevicePortal
 
             DataContractJsonSerializer deserializer = new DataContractJsonSerializer(typeof(T));
 
-            using (Stream dataStream = await this.Delete(uri))
+            try
             {
-                if ((dataStream != null) &&
-                    (dataStream.Length != 0))
+                using (Stream dataStream = await this.Delete(uri))
                 {
-                    JsonFormatCheck<T>(dataStream);
+                    if ((dataStream != null) &&
+                        (dataStream.Length != 0))
+                    {
+                        JsonFormatCheck<T>(dataStream);
 
-                    object response = deserializer.ReadObject(dataStream);
-                    data = (T)response;
+                        object response = deserializer.ReadObject(dataStream);
+                        data = (T)response;
+                    }
                 }
             }
+            catch (DevicePortalException e)
+            {
+                // If this isn't a retry and it failed due to a bad CSRF
+                // token, refresh the token and then retry.
+                if (allowRetry && this.IsBadCsrfToken(e))
+                {
+                    await this.RefreshCsrfToken();
+                    return await this.Delete<T>(apiPath, payload, false);
+                }
+                else
+                {
+                    throw e;
+                }
+            }
+
 
             return data;
         }

--- a/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper.Shared/HttpRest/RestPut.cs
+++ b/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper.Shared/HttpRest/RestPut.cs
@@ -57,11 +57,13 @@ namespace Microsoft.Tools.WindowsDevicePortal
         /// <param name="apiPath">The relative portion of the uri path that specifies the API to call.</param>
         /// <param name="bodyData">The data to be used for the HTTP request body.</param>
         /// <param name="payload">The query string portion of the uri path that provides the parameterized data.</param>
+        /// <param name="allowRetry">Allow the Put to be retried after refreshing the CSRF token.</param>
         /// <returns>Task tracking the PUT completion, optional response body.</returns>
         private async Task<T> Put<T, K>(
             string apiPath,
             K bodyData = null,
-            string payload = null) where T : new()
+            string payload = null,
+            bool allowRetry = true) where T : new()
                                    where K : class
         {
             T data = default(T);
@@ -96,15 +98,32 @@ namespace Microsoft.Tools.WindowsDevicePortal
 
             DataContractJsonSerializer deserializer = new DataContractJsonSerializer(typeof(T));
 
-            using (Stream dataStream = await this.Put(uri, streamContent))
+            try
             {
-                if ((dataStream != null) &&
-                    (dataStream.Length != 0))
+                using (Stream dataStream = await this.Put(uri, streamContent))
                 {
-                    JsonFormatCheck<T>(dataStream);
+                    if ((dataStream != null) &&
+                        (dataStream.Length != 0))
+                    {
+                        JsonFormatCheck<T>(dataStream);
 
-                    object response = deserializer.ReadObject(dataStream);
-                    data = (T)response;
+                        object response = deserializer.ReadObject(dataStream);
+                        data = (T)response;
+                    }
+                }
+            }
+            catch (DevicePortalException e)
+            {
+                // If this isn't a retry and it failed due to a bad CSRF
+                // token, refresh the token and then retry.
+                if (allowRetry && this.IsBadCsrfToken(e))
+                {
+                    await this.RefreshCsrfToken();
+                    return await this.Put<T, K>(apiPath, bodyData, payload, false);
+                }
+                else
+                {
+                    throw e;
                 }
             }
 

--- a/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper.UniversalWindows/HttpRest/RestDelete.cs
+++ b/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper.UniversalWindows/HttpRest/RestDelete.cs
@@ -26,10 +26,9 @@ namespace Microsoft.Tools.WindowsDevicePortal
         /// Submits the http delete request to the specified uri.
         /// </summary>
         /// <param name="uri">The uri to which the delete request will be issued.</param>
-        /// <param name="allowRetry">Allow the Post to be retried after issuing a Get call. Currently used for CSRF failures.</param>
         /// <returns>Task tracking HTTP completion</returns>
 #pragma warning disable 1998
-        private async Task<Stream> Delete(Uri uri, bool allowRetry = true)
+        private async Task<Stream> Delete(Uri uri)
         {
             IBuffer dataBuffer = null;
 
@@ -57,14 +56,6 @@ namespace Microsoft.Tools.WindowsDevicePortal
                 {
                     if (!response.IsSuccessStatusCode)
                     {
-                        // If this isn't a retry and it failed due to a bad CSRF
-                        // token, issue a GET to refresh the token and then retry.
-                        if (allowRetry && this.IsBadCsrfToken(response))
-                        {
-                            await this.RefreshCsrfToken();
-                            return await this.Delete(uri, false);
-                        }
-
                         throw new DevicePortalException(response);
                     }
 

--- a/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper.UniversalWindows/HttpRest/RestPost.cs
+++ b/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper.UniversalWindows/HttpRest/RestPost.cs
@@ -28,14 +28,12 @@ namespace Microsoft.Tools.WindowsDevicePortal
         /// <param name="uri">The uri to which the post request will be issued.</param>
         /// <param name="requestStream">Optional stream containing data for the request body.</param>
         /// <param name="requestStreamContentType">The type of that request body data.</param>
-        /// <param name="allowRetry">Allow the Post to be retried after issuing a Get call. Currently used for CSRF failures.</param>
         /// <returns>Task tracking the completion of the POST request</returns>
 #pragma warning disable 1998
         private async Task<Stream> Post(
             Uri uri,
             Stream requestStream = null,
-            string requestStreamContentType = null,
-            bool allowRetry = true)
+            string requestStreamContentType = null)
         {
             HttpStreamContent requestContent = null;
             IBuffer dataBuffer = null;
@@ -71,14 +69,6 @@ namespace Microsoft.Tools.WindowsDevicePortal
                 {
                     if (!response.IsSuccessStatusCode)
                     {
-                        // If this isn't a retry and it failed due to a bad CSRF
-                        // token, issue a GET to refresh the token and then retry.
-                        if (allowRetry && this.IsBadCsrfToken(response))
-                        {
-                            await this.RefreshCsrfToken();
-                            return await this.Post(uri, requestStream, requestStreamContentType, false);
-                        }
-
                         throw new DevicePortalException(response);
                     }
 

--- a/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper.UniversalWindows/HttpRest/RestPut.cs
+++ b/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper.UniversalWindows/HttpRest/RestPut.cs
@@ -27,13 +27,11 @@ namespace Microsoft.Tools.WindowsDevicePortal
         /// </summary>
         /// <param name="uri">The uri to which the put request will be issued.</param>
         /// <param name="body">The HTTP content comprising the body of the request.</param>
-        /// <param name="allowRetry">Allow the Post to be retried after issuing a Get call. Currently used for CSRF failures.</param>
         /// <returns>Task tracking the PUT completion.</returns>
 #pragma warning disable 1998
         private async Task<Stream> Put(
             Uri uri,
-            IHttpContent body = null,
-            bool allowRetry = true)
+            IHttpContent body = null)
         {
             IBuffer dataBuffer = null;
 
@@ -62,14 +60,6 @@ namespace Microsoft.Tools.WindowsDevicePortal
                 {
                     if (!response.IsSuccessStatusCode)
                     {
-                        // If this isn't a retry and it failed due to a bad CSRF
-                        // token, issue a GET to refresh the token and then retry.
-                        if (allowRetry && this.IsBadCsrfToken(response))
-                        {
-                            await this.RefreshCsrfToken();
-                            return await this.Put(uri, body, false);
-                        }
-
                         throw new DevicePortalException(response);
                     }
 

--- a/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper/HttpRest/RestDelete.cs
+++ b/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper/HttpRest/RestDelete.cs
@@ -21,9 +21,8 @@ namespace Microsoft.Tools.WindowsDevicePortal
         /// Submits the http delete request to the specified uri.
         /// </summary>
         /// <param name="uri">The uri to which the delete request will be issued.</param>
-        /// <param name="allowRetry">Allow the Post to be retried after issuing a Get call. Currently used for CSRF failures.</param>
         /// <returns>Task tracking HTTP completion</returns>
-        private async Task<Stream> Delete(Uri uri, bool allowRetry = true)
+        private async Task<Stream> Delete(Uri uri)
         {
             MemoryStream dataStream = null;
 
@@ -44,14 +43,6 @@ namespace Microsoft.Tools.WindowsDevicePortal
                 {
                     if (!response.IsSuccessStatusCode)
                     {
-                        // If this isn't a retry and it failed due to a bad CSRF
-                        // token, issue a GET to refresh the token and then retry.
-                        if (allowRetry && this.IsBadCsrfToken(response))
-                        {
-                            await this.RefreshCsrfToken();
-                            return await this.Delete(uri, false);
-                        }
-
                         throw new DevicePortalException(response);
                     }
 

--- a/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper/HttpRest/RestPost.cs
+++ b/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper/HttpRest/RestPost.cs
@@ -23,13 +23,11 @@ namespace Microsoft.Tools.WindowsDevicePortal
         /// <param name="uri">The uri to which the post request will be issued.</param>
         /// <param name="requestStream">Optional stream containing data for the request body.</param>
         /// <param name="requestStreamContentType">The type of that request body data.</param>
-        /// <param name="allowRetry">Allow the Post to be retried after issuing a Get call. Currently used for CSRF failures.</param>
         /// <returns>Task tracking the completion of the POST request</returns>
         private async Task<Stream> Post(
             Uri uri,
             Stream requestStream = null,
-            string requestStreamContentType = null,
-            bool allowRetry = true)
+            string requestStreamContentType = null)
         {
             StreamContent requestContent = null;
             MemoryStream responseDataStream = null;
@@ -58,14 +56,6 @@ namespace Microsoft.Tools.WindowsDevicePortal
                 {
                     if (!response.IsSuccessStatusCode)
                     {
-                        // If this isn't a retry and it failed due to a bad CSRF
-                        // token, issue a GET to refresh the token and then retry.
-                        if (allowRetry && this.IsBadCsrfToken(response))
-                        {
-                            await this.RefreshCsrfToken();
-                            return await this.Post(uri, requestStream, requestStreamContentType, false);
-                        }
-
                         throw new DevicePortalException(response);
                     }
 

--- a/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper/HttpRest/RestPut.cs
+++ b/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper/HttpRest/RestPut.cs
@@ -22,12 +22,10 @@ namespace Microsoft.Tools.WindowsDevicePortal
         /// </summary>
         /// <param name="uri">The uri to which the put request will be issued.</param>
         /// <param name="body">The HTTP content comprising the body of the request.</param>
-        /// <param name="allowRetry">Allow the Post to be retried after issuing a Get call. Currently used for CSRF failures.</param>
         /// <returns>Task tracking the PUT completion.</returns>
         private async Task<Stream> Put(
             Uri uri,
-            HttpContent body = null,
-            bool allowRetry = true)
+            HttpContent body = null)
         {
             MemoryStream dataStream = null;
 
@@ -49,14 +47,6 @@ namespace Microsoft.Tools.WindowsDevicePortal
                 {
                     if (!response.IsSuccessStatusCode)
                     {
-                        // If this isn't a retry and it failed due to a bad CSRF
-                        // token, issue a GET to refresh the token and then retry.
-                        if (allowRetry && this.IsBadCsrfToken(response))
-                        {
-                            await this.RefreshCsrfToken();
-                            return await this.Put(uri, body, false);
-                        }
-
                         throw new DevicePortalException(response);
                     }
 


### PR DESCRIPTION
Looks like Xbox has some strange builds where the CSRF token is still bad, but this fixes the retry (Issue #173) at least. I'll open a new issue to track the failure.