### PR TITLE
simplify getting the websocket uri. no longer uses regular expressions

### DIFF
--- a/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper.UniversalWindows/DefaultDevicePortalConnection.cs
+++ b/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper.UniversalWindows/DefaultDevicePortalConnection.cs
@@ -6,10 +6,6 @@
 
 using System;
 using System.Net;
-using System.Text.RegularExpressions;
-using Windows.Foundation;
-using Windows.Security.Cryptography.Certificates;
-using Windows.Storage.Streams;
 using static Microsoft.Tools.WindowsDevicePortal.DevicePortal;
 
 namespace Microsoft.Tools.WindowsDevicePortal
@@ -57,16 +53,13 @@ namespace Microsoft.Tools.WindowsDevicePortal
                     return null;
                 }
 
-                string absoluteUri = this.Connection.AbsoluteUri;
+                // Convert the scheme from http[s] to ws[s].
+                string scheme = this.Connection.Scheme.Equals("https", StringComparison.OrdinalIgnoreCase) ? "wss" : "ws";
 
-                if (absoluteUri.StartsWith("https", StringComparison.OrdinalIgnoreCase))
-                {
-                    return new Uri(Regex.Replace(absoluteUri, "https", "wss", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant));
-                }
-                else
-                {
-                    return new Uri(Regex.Replace(absoluteUri, "http", "ws", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant));
-                }
+                return new Uri(
+                    string.Format("{0}://{1}",
+                        scheme,
+                        this.Connection.Authority));
             }
         }
 

--- a/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper/DefaultDevicePortalConnection.cs
+++ b/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper/DefaultDevicePortalConnection.cs
@@ -8,7 +8,6 @@ using System;
 using System.Net;
 using System.Net.Security;
 using System.Security.Cryptography.X509Certificates;
-using System.Text.RegularExpressions;
 using static Microsoft.Tools.WindowsDevicePortal.DevicePortal;
 
 namespace Microsoft.Tools.WindowsDevicePortal
@@ -66,16 +65,13 @@ namespace Microsoft.Tools.WindowsDevicePortal
                     return null;
                 }
 
-                string absoluteUri = this.Connection.AbsoluteUri;
+                // Convert the scheme from http[s] to ws[s].
+                string scheme = this.Connection.Scheme.Equals("https", StringComparison.OrdinalIgnoreCase) ? "wss" : "ws";
 
-                if (absoluteUri.StartsWith("https", StringComparison.OrdinalIgnoreCase))
-                {
-                    return new Uri(Regex.Replace(absoluteUri, "https", "wss", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant));
-                }
-                else
-                {
-                    return new Uri(Regex.Replace(absoluteUri, "http", "ws", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant));
-                }
+                return new Uri(
+                    string.Format("{0}://{1}",
+                        scheme,
+                        this.Connection.Authority));
             }
         }
 


### PR DESCRIPTION
also removes some unused namespaces from the using block