### PR TITLE
fix for issue 181 and updating the connection

### DIFF
--- a/Samples/SampleWdpClient.UniversalWindows/MainPage.xaml.cs
+++ b/Samples/SampleWdpClient.UniversalWindows/MainPage.xaml.cs
@@ -113,7 +113,7 @@ namespace SampleWdpClient.UniversalWindows
                         // remainder of this session.
                         if (allowUntrusted)
                         {
-                            await portal.GetRootDeviceCertificate(true);
+                            this.certificate = await portal.GetRootDeviceCertificate(true);
                         }
                         await portal.Connect(manualCertificate: this.certificate);
                     }

--- a/WindowsDevicePortalWrapper/UnitTestProject/WDPMockImplementations/MockDevicePortalConnection.cs
+++ b/WindowsDevicePortalWrapper/UnitTestProject/WDPMockImplementations/MockDevicePortalConnection.cs
@@ -87,9 +87,13 @@ namespace Microsoft.Tools.WindowsDevicePortal.Tests
         /// <summary>
         ///  The Mock will never update the connection.
         /// </summary>
-        /// <param name="ipConfig">IP info</param>
-        /// <param name="requiresHttps">https required</param>
-        public void UpdateConnection(IpConfiguration ipConfig, bool requiresHttps)
+        /// <param name="ipConfig">Object that describes the current network configuration.</param>
+        /// <param name="requiresHttps">True if an https connection is required, false otherwise.</param>
+        /// <param name="preservePort">True if the previous connection's port is to continue to be used, false otherwise.</param>
+        public void UpdateConnection(
+            IpConfiguration ipConfig, 
+            bool requiresHttps,
+            bool preservePort)
         {
             throw new NotImplementedException();
         }

--- a/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper.Shared/DevicePortal.cs
+++ b/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper.Shared/DevicePortal.cs
@@ -256,7 +256,21 @@ namespace Microsoft.Tools.WindowsDevicePortal
                         DeviceConnectionStatus.Connecting,
                         DeviceConnectionPhase.UpdatingDeviceAddress,
                         connectionPhaseDescription);
-                    this.deviceConnection.UpdateConnection(await this.GetIpConfig(), requiresHttps);
+                    
+                    bool preservePort = true;
+                    // HoloLens and Mobile are the only devices that support USB.
+                    // They require the port to be changed when the connection is updated
+                    // to WiFi.
+                    if ((this.Platform == DevicePortalPlatforms.HoloLens) ||
+                        (this.Platform == DevicePortalPlatforms.Mobile))
+                    {
+                        preservePort = false;
+                    }
+
+                    this.deviceConnection.UpdateConnection(
+                        await this.GetIpConfig(), 
+                        requiresHttps,
+                        preservePort);
                 }
 
                 this.SendConnectionStatus(

--- a/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper.Shared/HoloLens/MixedRealityCapture.cs
+++ b/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper.Shared/HoloLens/MixedRealityCapture.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Tools.WindowsDevicePortal
         /// <summary>
         /// API for getting a high resolution live Holographic Mixed Reality Capture stream.
         /// </summary>
-        public static readonly string MrcLiveStreamHighwResApi = "api/holographic/stream/live_high.mp4";
+        public static readonly string MrcLiveStreamHighResApi = "api/holographic/stream/live_high.mp4";
 
         /// <summary>
         /// API for getting a low resolution live Holographic Mixed Reality Capture stream.
@@ -81,8 +81,8 @@ namespace Microsoft.Tools.WindowsDevicePortal
         /// Removes a Mixed Reality Capture file from the device's local storage.
         /// </summary>
         /// <param name="fileName">The name of the file to be deleted.</param>
-        /// <remarks>This method is only supported on HoloLens devices.</remarks>
         /// <returns>Task tracking completion of the REST call.</returns>
+        /// <remarks>This method is only supported on HoloLens devices.</remarks>
         public async Task DeleteMrcFile(string fileName)
         {
             if (!Utilities.IsHoloLens(this.Platform, this.DeviceFamily))
@@ -96,10 +96,94 @@ namespace Microsoft.Tools.WindowsDevicePortal
         }
 
         /// <summary>
+        /// Retrieve the Uri for the high resolution Mixed Reality Capture live stream.
+        /// </summary>
+        /// <param name="includeHolograms">Specifies whether or not to include holograms</param>
+        /// <param name="includeColorCamera">Specifies whether or not to include the color camera</param>
+        /// <param name="includeMicrophone">Specifies whether or not to include microphone data</param>
+        /// <param name="includeAudio">Specifies whether or not to include audio data</param>
+        /// <returns>Uri used to retreive the Mixed Reality Capture stream.</returns>
+        /// <remarks>This method is only supported on HoloLens devices.</remarks>
+        public Uri GetHighResolutionMrcLiveStreamUri(
+            bool includeHolograms = true,
+            bool includeColorCamera = true,
+            bool includeMicrophone = true,
+            bool includeAudio = true)
+        {
+            string payload = string.Format(
+                "holo={0}&pv={1}&mic={2}&loopback={3}",
+                includeHolograms,
+                includeColorCamera,
+                includeMicrophone,
+                includeAudio).ToLower();
+
+            return Utilities.BuildEndpoint(
+                this.deviceConnection.Connection,
+                MrcLiveStreamHighResApi,
+                payload);
+        }
+
+        /// <summary>
+        /// Retrieve the Uri for the low resolution Mixed Reality Capture live stream.
+        /// </summary>
+        /// <param name="includeHolograms">Specifies whether or not to include holograms</param>
+        /// <param name="includeColorCamera">Specifies whether or not to include the color camera</param>
+        /// <param name="includeMicrophone">Specifies whether or not to include microphone data</param>
+        /// <param name="includeAudio">Specifies whether or not to include audio data</param>
+        /// <returns>Uri used to retreive the Mixed Reality Capture stream.</returns>
+        /// <remarks>This method is only supported on HoloLens devices.</remarks>
+        public Uri GetLowResolutionMrcLiveStreamUri(
+            bool includeHolograms = true,
+            bool includeColorCamera = true,
+            bool includeMicrophone = true,
+            bool includeAudio = true)
+        {
+            string payload = string.Format(
+                "holo={0}&pv={1}&mic={2}&loopback={3}",
+                includeHolograms,
+                includeColorCamera,
+                includeMicrophone,
+                includeAudio).ToLower();
+
+            return Utilities.BuildEndpoint(
+                this.deviceConnection.Connection,
+                MrcLiveStreamLowResApi,
+                payload);
+        }
+
+        /// <summary>
+        /// Retrieve the Uri for the medium resolution Mixed Reality Capture live stream.
+        /// </summary>
+        /// <param name="includeHolograms">Specifies whether or not to include holograms</param>
+        /// <param name="includeColorCamera">Specifies whether or not to include the color camera</param>
+        /// <param name="includeMicrophone">Specifies whether or not to include microphone data</param>
+        /// <param name="includeAudio">Specifies whether or not to include audio data</param>
+        /// <returns>Uri used to retreive the Mixed Reality Capture stream.</returns>
+        /// <remarks>This method is only supported on HoloLens devices.</remarks>
+        public Uri GetMediumResolutionMrcLiveStreamUri(
+            bool includeHolograms = true,
+            bool includeColorCamera = true,
+            bool includeMicrophone = true,
+            bool includeAudio = true)
+        {
+            string payload = string.Format(
+                "holo={0}&pv={1}&mic={2}&loopback={3}",
+                includeHolograms,
+                includeColorCamera,
+                includeMicrophone,
+                includeAudio).ToLower();
+
+            return Utilities.BuildEndpoint(
+                this.deviceConnection.Connection,
+                MrcLiveStreamMediumResApi,
+                payload);
+        }
+
+        /// <summary>
         /// Gets the capture file data
         /// </summary>
-        /// <param name="fileName">Name of the file to retrieve</param>
-        /// <param name="isThumbnailRequest">Whether or not we just want a thumbnail</param>
+        /// <param name="fileName">Name of the file to retrieve.</param>
+        /// <param name="isThumbnailRequest">Specifies whether or not we are requesting a thumbnail image.</param>
         /// <returns>Byte array containing the file data.</returns>
         /// <remarks>This method is only supported on HoloLens devices.</remarks>
         public async Task<byte[]> GetMrcFileData(
@@ -155,6 +239,36 @@ namespace Microsoft.Tools.WindowsDevicePortal
         }
 
         /// <summary>
+        /// Retrieve the Uri for the Mixed Reality Capture live stream using the default resolution.
+        /// </summary>
+        /// <param name="includeHolograms">Specifies whether or not to include holograms</param>
+        /// <param name="includeColorCamera">Specifies whether or not to include the color camera</param>
+        /// <param name="includeMicrophone">Specifies whether or not to include microphone data</param>
+        /// <param name="includeAudio">Specifies whether or not to include audio data</param>
+        /// <returns>Uri used to retreive the Mixed Reality Capture stream.</returns>
+        /// <remarks>This method is only supported on HoloLens devices.</remarks>
+        public Uri GetMrcLiveStreamUri(
+            bool includeHolograms = true,
+            bool includeColorCamera = true,
+            bool includeMicrophone = true,
+            bool includeAudio = true)
+        {
+            string payload = string.Format(
+                "holo={0}&pv={1}&mic={2}&loopback={3}",
+                includeHolograms,
+                includeColorCamera,
+                includeMicrophone,
+                includeAudio).ToLower();
+
+            return Utilities.BuildEndpoint(
+                this.deviceConnection.Connection,
+                MrcLiveStreamApi,
+                payload);
+        }
+
+        // TODO: GetMrcSettings()
+
+        /// <summary>
         /// Gets the status of the reality capture
         /// </summary>
         /// <returns>Status of the capture</returns>
@@ -181,15 +295,17 @@ namespace Microsoft.Tools.WindowsDevicePortal
             return await this.GetMrcFileData(fileName, true);
         }
 
+        // TODO: SetMrcSettings()
+
         /// <summary>
         /// Starts a Mixed Reality Capture recording.
         /// </summary>
-        /// <param name="includeHolograms">Whether to include holograms</param>
-        /// <param name="includeColorCamera">Whether to include the color camera</param>
-        /// <param name="includeMicrophone">Whether to include microphone data</param>
-        /// <param name="includeAudio">Whether to include audio data</param>
-        /// <remarks>This method is only supported on HoloLens devices.</remarks>
+        /// <param name="includeHolograms">Specifies whether or not to include holograms</param>
+        /// <param name="includeColorCamera">Specifies whether or not to include the color camera</param>
+        /// <param name="includeMicrophone">Specifies whether or not to include microphone data</param>
+        /// <param name="includeAudio">Specifies whether or not to include audio data</param>
         /// <returns>Task tracking completion of the REST call.</returns>
+        /// <remarks>This method is only supported on HoloLens devices.</remarks>
         public async Task StartMrcRecording(
             bool includeHolograms = true,
             bool includeColorCamera = true,
@@ -216,8 +332,8 @@ namespace Microsoft.Tools.WindowsDevicePortal
         /// <summary>
         /// Stops the Mixed Reality Capture recording
         /// </summary>
-        /// <remarks>This method is only supported on HoloLens devices.</remarks>
         /// <returns>Task tracking completion of the REST call.</returns>
+        /// <remarks>This method is only supported on HoloLens devices.</remarks>
         public async Task StopMrcRecording()
         {
             if (!Utilities.IsHoloLens(this.Platform, this.DeviceFamily))
@@ -231,10 +347,10 @@ namespace Microsoft.Tools.WindowsDevicePortal
         /// <summary>
         /// Take a Mixed Reality Capture photo
         /// </summary>
-        /// <param name="includeHolograms">Whether to include holograms</param>
-        /// <param name="includeColorCamera">Whether to include the color camera</param>
-        /// <remarks>This method is only supported on HoloLens devices.</remarks>
+        /// <param name="includeHolograms">Specifies whether or not to include holograms</param>
+        /// <param name="includeColorCamera">Specifies whether or not to include the color camera</param>
         /// <returns>Task tracking completion of the REST call.</returns>
+        /// <remarks>This method is only supported on HoloLens devices.</remarks>
         public async Task TakeMrcPhoto(
             bool includeHolograms = true,
             bool includeColorCamera = true)

--- a/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper.Shared/Interfaces/IDevicePortalConnection.cs
+++ b/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper.Shared/Interfaces/IDevicePortalConnection.cs
@@ -55,8 +55,10 @@ namespace Microsoft.Tools.WindowsDevicePortal
         /// </summary>
         /// <param name="ipConfig">Object that describes the current network configuration.</param>
         /// <param name="requiresHttps">True if an https connection is required, false otherwise.</param>
+        /// <param name="preservePort">True if the previous connection's port is to continue to be used, false otherwise.</param>
         void UpdateConnection(
             IpConfiguration ipConfig,
-            bool requiresHttps);
+            bool requiresHttps,
+            bool preservePort);
     }
 }

--- a/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper.UniversalWindows/DefaultDevicePortalConnection.cs
+++ b/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper.UniversalWindows/DefaultDevicePortalConnection.cs
@@ -56,10 +56,7 @@ namespace Microsoft.Tools.WindowsDevicePortal
                 // Convert the scheme from http[s] to ws[s].
                 string scheme = this.Connection.Scheme.Equals("https", StringComparison.OrdinalIgnoreCase) ? "wss" : "ws";
 
-                return new Uri(
-                    string.Format("{0}://{1}",
-                        scheme,
-                        this.Connection.Authority));
+                return new Uri(string.Format("{0}://{1}", scheme, this.Connection.Authority));
             }
         }
 
@@ -106,11 +103,13 @@ namespace Microsoft.Tools.WindowsDevicePortal
         /// <summary>
         /// Updates the device's connection Uri.
         /// </summary>
-        /// <param name="ipConfig">The device's IP configuration data.</param>
-        /// <param name="requiresHttps">Indicates whether or not to always require a secure connection.</param>
+        /// <param name="ipConfig">Object that describes the current network configuration.</param>
+        /// <param name="requiresHttps">True if an https connection is required, false otherwise.</param>
+        /// <param name="preservePort">True if the previous connection's port is to continue to be used, false otherwise.</param>
         public void UpdateConnection(
             IpConfiguration ipConfig,
-            bool requiresHttps = false)
+            bool requiresHttps,
+            bool preservePort)
         {
             Uri newConnection = null;
 
@@ -121,11 +120,20 @@ namespace Microsoft.Tools.WindowsDevicePortal
                     // We take the first, non-169.x.x.x address we find that is not 0.0.0.0.
                     if ((addressInfo.Address != "0.0.0.0") && !addressInfo.Address.StartsWith("169."))
                     {
+                        string address = addressInfo.Address;
+                        if (preservePort)
+                        {
+                            address = string.Format(
+                                "{0}:{1}",
+                                address,
+                                this.Connection.Port);
+                        }
+
                         newConnection = new Uri(
                             string.Format(
                                 "{0}://{1}", 
                                 requiresHttps ? "https" : "http",
-                                this.Connection.Authority));
+                                address));
                         break;
                     }
                 }

--- a/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper.UniversalWindows/project.json
+++ b/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper.UniversalWindows/project.json
@@ -1,7 +1,6 @@
 ﻿{
   "dependencies": {
     "Microsoft.NETCore.UniversalWindowsPlatform": "5.1.0",
-    "StyleCop.MSBuild": "4.7.54"
   },
   "frameworks": {
     "uap10.0": {}

--- a/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper.UniversalWindows/project.json
+++ b/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper.UniversalWindows/project.json
@@ -1,6 +1,7 @@
 ﻿{
   "dependencies": {
-    "Microsoft.NETCore.UniversalWindowsPlatform": "5.1.0"
+    "Microsoft.NETCore.UniversalWindowsPlatform": "5.1.0",
+    "StyleCop.MSBuild": "4.7.54"
   },
   "frameworks": {
     "uap10.0": {}

--- a/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper/DefaultDevicePortalConnection.cs
+++ b/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper/DefaultDevicePortalConnection.cs
@@ -136,11 +136,13 @@ namespace Microsoft.Tools.WindowsDevicePortal
         /// <summary>
         /// Updates the device's connection Uri.
         /// </summary>
-        /// <param name="ipConfig">The device's IP configuration data.</param>
-        /// <param name="requiresHttps">Indicates whether or not to always require a secure connection.</param>
+        /// <param name="ipConfig">Object that describes the current network configuration.</param>
+        /// <param name="requiresHttps">True if an https connection is required, false otherwise.</param>
+        /// <param name="preservePort">True if the previous connection's port is to continue to be used, false otherwise.</param>
         public void UpdateConnection(
             IpConfiguration ipConfig,
-            bool requiresHttps = false)
+            bool requiresHttps,
+            bool preservePort)
         {
             Uri newConnection = null;
 
@@ -151,11 +153,19 @@ namespace Microsoft.Tools.WindowsDevicePortal
                     // We take the first, non-169.x.x.x address we find that is not 0.0.0.0.
                     if ((addressInfo.Address != "0.0.0.0") && !addressInfo.Address.StartsWith("169."))
                     {
+                        string address = addressInfo.Address;
+                        if (preservePort)
+                        {
+                            address = string.Format("{0}:{1}",
+                                address,
+                                this.Connection.Port);
+                        }
+
                         newConnection = new Uri(
                             string.Format(
                                 "{0}://{1}", 
                                 requiresHttps ? "https" : "http",
-                                this.Connection.Authority));
+                                address));
                         break;
                     }
                 }


### PR DESCRIPTION
This resolves #181 as well as issues with the DefaultDevicePortalConnection implementation of UpdateConnection.

The UpdateConnection change is to add a third parameter to specify whether or not to preserve the original connection's port. On HoloLens and Mobile, the port number is not preserved as the most common use of this is to switch from USB (port 10080) to WiFi (port number based on scheme)

Also implemented are methods to get the correctly formatted URI for accessing the Mixed Reality Capture live stream data on HoloLens.

