### PR TITLE
remove duplicate reference

### DIFF
--- a/WindowsDevicePortalWrapper/UnitTestProject/UnitTestProject.csproj
+++ b/WindowsDevicePortalWrapper/UnitTestProject/UnitTestProject.csproj
@@ -389,12 +389,6 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\WindowsDevicePortalWrapper\WindowsDevicePortalWrapper.csproj">
-      <Project>{6A9E862E-5CDA-4A8A-BBC0-56E9EA921E39}</Project>
-      <Name>WindowsDevicePortalWrapper</Name>
-    </ProjectReference>
-  </ItemGroup>
   <Choose>
     <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">
       <ItemGroup>


### PR DESCRIPTION
this clears up the "conflicts with the imported type" warnings when building UnitTestProject