### PR TITLE
Change array return types to Lists for #189

### DIFF
--- a/WindowsDevicePortalWrapper/UnitTestProject/Core/PerformanceDataTests.cs
+++ b/WindowsDevicePortalWrapper/UnitTestProject/Core/PerformanceDataTests.cs
@@ -132,7 +132,7 @@ namespace Microsoft.Tools.WindowsDevicePortal.Tests.Core
         /// <param name="runningProcesses">The <see cref="RunningProcesses" /> to validate.</param>
         private static void ValidateRunningProcessesAsync(RunningProcesses runningProcesses)
         {
-            List<DeviceProcessInfo> processes = new List<DeviceProcessInfo>(runningProcesses.Processes);
+            List<DeviceProcessInfo> processes = runningProcesses.Processes;
 
             // Check some known things about this response.
             Assert.AreEqual(2, processes.Count);

--- a/WindowsDevicePortalWrapper/UnitTestProject/Device-VersionTests/IoT/IoT_rs1_release.cs
+++ b/WindowsDevicePortalWrapper/UnitTestProject/Device-VersionTests/IoT/IoT_rs1_release.cs
@@ -5,6 +5,7 @@
 //----------------------------------------------------------------------------------------------
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
@@ -589,7 +590,7 @@ namespace Microsoft.Tools.WindowsDevicePortal.Tests
             HeadlessAppsListInfo appsList = getTask.Result;
 
             // Check some known things about this response.
-            Assert.AreEqual(true, appsList.AppPackages[0].IsStartup);
+            Assert.AreEqual(true, appsList.AppPackages.First().IsStartup);
         }
 
         /// <summary>
@@ -771,7 +772,7 @@ namespace Microsoft.Tools.WindowsDevicePortal.Tests
             IscInterfacesInfo icsInterfaceInfo = getTask.Result;
 
             // Check some known things about this response.
-            Assert.AreEqual("Broadcom 802.11n Wireless SDIO Adapter", icsInterfaceInfo.PrivateInterfaces[0]);
+            Assert.AreEqual("Broadcom 802.11n Wireless SDIO Adapter", icsInterfaceInfo.PrivateInterfaces.First());
         }
 
         /// <summary>

--- a/WindowsDevicePortalWrapper/UnitTestProject/Device-VersionTests/XboxOne/XboxOne_rs1_xbox_rel_1608.cs
+++ b/WindowsDevicePortalWrapper/UnitTestProject/Device-VersionTests/XboxOne/XboxOne_rs1_xbox_rel_1608.cs
@@ -669,7 +669,7 @@ namespace Microsoft.Tools.WindowsDevicePortal.Tests
         /// <param name="runningProcesses">The <see cref="RunningProcesses" /> to validate.</param>
         private static void ValidateRunningProcessesAsync(RunningProcesses runningProcesses)
         {
-            List<DeviceProcessInfo> processes = new List<DeviceProcessInfo>(runningProcesses.Processes);
+            List<DeviceProcessInfo> processes = runningProcesses.Processes;
 
             // Check some known things about this response.
             Assert.AreEqual(75, processes.Count);

--- a/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper.Shared/Core/PerformanceData.cs
+++ b/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper.Shared/Core/PerformanceData.cs
@@ -412,7 +412,7 @@ namespace Microsoft.Tools.WindowsDevicePortal
             /// Gets list of running processes.
             /// </summary>
             [DataMember(Name = "Processes")]
-            public DeviceProcessInfo[] Processes { get; private set; }
+            public List<DeviceProcessInfo> Processes { get; private set; }
 
             /// <summary>
             /// Checks to see if this process Id is in the list of processes
@@ -423,18 +423,14 @@ namespace Microsoft.Tools.WindowsDevicePortal
             {
                 bool found = false;
 
-                if (this.Processes != null)
+                foreach (DeviceProcessInfo pi in this.Processes)
                 {
-                    foreach (DeviceProcessInfo pi in this.Processes)
+                    if (pi.ProcessId == processId)
                     {
-                        if (pi.ProcessId == processId)
-                        {
-                            found = true;
-                            break;
-                        }
+                        found = true;
+                        break;
                     }
                 }
-
                 return found;
             }
 
@@ -448,21 +444,17 @@ namespace Microsoft.Tools.WindowsDevicePortal
             {
                 bool found = false;
 
-                if (this.Processes != null)
+                foreach (DeviceProcessInfo pi in this.Processes)
                 {
-                    foreach (DeviceProcessInfo pi in this.Processes)
+                    if (string.Compare(
+                            pi.PackageFullName,
+                            packageName,
+                            caseSensitive ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase) == 0)
                     {
-                        if (string.Compare(
-                                pi.PackageFullName,
-                                packageName,
-                                caseSensitive ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase) == 0)
-                        {
-                            found = true;
-                            break;
-                        }
+                        found = true;
+                        break;
                     }
                 }
-
                 return found;
             }
         }

--- a/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper.Shared/IoT/ApplicationManager.cs
+++ b/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper.Shared/IoT/ApplicationManager.cs
@@ -5,6 +5,7 @@
 //----------------------------------------------------------------------------------------------
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.Serialization;
 using System.Threading.Tasks;
@@ -119,7 +120,7 @@ namespace Microsoft.Tools.WindowsDevicePortal
             /// Gets or sets the application packages
             /// </summary>
             [DataMember(Name = "AppPackages")]
-            public AppPackage[] AppPackages { get; private set; }
+            public List<AppPackage> AppPackages { get; private set; }
         }
 
         [DataContract]
@@ -148,7 +149,7 @@ namespace Microsoft.Tools.WindowsDevicePortal
             /// Gets the list of headless application packages
             /// </summary>
             [DataMember(Name = "AppPackages")]
-            public AppPackage[] AppPackages { get; private set; }
+            public List<AppPackage> AppPackages { get; private set; }
         }
        
         #endregion // Data contract

--- a/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper.Shared/IoT/BluetoothConnectivity.cs
+++ b/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper.Shared/IoT/BluetoothConnectivity.cs
@@ -9,6 +9,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Runtime.Serialization;
 using System.Threading.Tasks;
 using System.Threading;
+using System.Collections.Generic;
 
 namespace Microsoft.Tools.WindowsDevicePortal
 {
@@ -359,7 +360,7 @@ namespace Microsoft.Tools.WindowsDevicePortal
             /// Returns a list of available devices
             /// </summary>
             [DataMember(Name = "AvailableDevices")]
-            public BluetoothDeviceInfo[] AvailableDevices;
+            public List<BluetoothDeviceInfo> AvailableDevices { get; private set; }
         }
         public class BluetoothDeviceInfo 
         {
@@ -386,7 +387,7 @@ namespace Microsoft.Tools.WindowsDevicePortal
             /// Returns a list of paired devices
             /// </summary>
             [DataMember(Name = "PairedDevices")]
-            public BluetoothDeviceInfo[] PairedDevices;
+            public List<BluetoothDeviceInfo> PairedDevices { get; private set; }
         }
 
         /// <summary>
@@ -399,7 +400,7 @@ namespace Microsoft.Tools.WindowsDevicePortal
             /// Returns the pair results
             /// </summary>
             [DataMember(Name = "PairResult")]
-            public PairResult PairResult;
+            public PairResult PairResult { get; private set; }
         }
 
         public class PairResult

--- a/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper.Shared/IoT/DeviceInfo.cs
+++ b/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper.Shared/IoT/DeviceInfo.cs
@@ -5,6 +5,7 @@
 //----------------------------------------------------------------------------------------------
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.Serialization;
 using System.Threading.Tasks;
@@ -245,7 +246,7 @@ namespace Microsoft.Tools.WindowsDevicePortal
             /// Gets the list of all timezones
             /// </summary>
             [DataMember(Name = "Timezones")]
-            public Timezone[] Timezones { get; private set; }
+            public List<Timezone> Timezones { get; private set; }
         }
 
         /// <summary>
@@ -345,7 +346,7 @@ namespace Microsoft.Tools.WindowsDevicePortal
             /// Gets the list of all the controller drivers information
             /// </summary>         
             [DataMember(Name = "ControllersDrivers")]
-            public string[] ControllersDrivers { get; private set; }
+            public List<string> ControllersDrivers { get; private set; }
 
             /// <summary>
             /// Gets the request for reboot
@@ -383,7 +384,7 @@ namespace Microsoft.Tools.WindowsDevicePortal
             /// Gets the list of resolution specifications
             /// </summary>
             [DataMember(Name = "Resolutions")]
-            public Resolution[] Resolutions { get; private set; }
+            public List<Resolution> Resolutions { get; private set; }
         }
 
         /// <summary>

--- a/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper.Shared/IoT/IcsManager.cs
+++ b/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper.Shared/IoT/IcsManager.cs
@@ -5,6 +5,7 @@
 //----------------------------------------------------------------------------------------------
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.Serialization;
 using System.Threading.Tasks;
@@ -71,13 +72,13 @@ namespace Microsoft.Tools.WindowsDevicePortal
             /// Gets the internet connection sharing(ICS) private interfaces.
             /// </summary>
             [DataMember(Name = "PrivateInterfaces")]
-            public string[] PrivateInterfaces { get; private set; }
+            public List<string> PrivateInterfaces { get; private set; }
 
             /// <summary>
             ///  Gets the internet connection sharing(ICS) public interfaces.
             /// </summary>
             [DataMember(Name = "PublicInterfaces")]
-            public string[] PublicInterfaces { get; private set; }
+            public List<string> PublicInterfaces { get; private set; }
         }
         #endregion // Data contract
     }

--- a/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper.Shared/IoT/Limpet.cs
+++ b/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper.Shared/IoT/Limpet.cs
@@ -5,6 +5,7 @@
 //----------------------------------------------------------------------------------------------
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.Serialization;
 using System.Threading.Tasks;
@@ -160,7 +161,7 @@ namespace Microsoft.Tools.WindowsDevicePortal
             /// Gets TPM ACPI Tables. 
             /// </summary>
             [DataMember(Name = "AcpiTables")]
-            public string[] AcpiTables { get; private set; }        
+            public List<string> AcpiTables { get; private set; }        
         }
 
         /// <summary>


### PR DESCRIPTION
Alters most tests to use Linq .First() or the existing list rather than [0] or new List<>(return value). This is for #189 

@namkedia - I added get; private set for a few of the IoT objects - can you verify if that's correct usage?