### PR TITLE
Add .appxbundle association to the UWP sample manifest

### DIFF
--- a/Samples/SampleWdpClient.UniversalWindows/Package.appxmanifest
+++ b/Samples/SampleWdpClient.UniversalWindows/Package.appxmanifest
@@ -23,7 +23,6 @@
       <Extensions>
         <uap:Extension Category="windows.fileTypeAssociation">
           <uap:FileTypeAssociation Name="apppackagebundle">
-            <uap:EditFlags OpenIsSafe="true" />
             <uap:SupportedFileTypes>
               <uap:FileType>.appxbundle</uap:FileType>
             </uap:SupportedFileTypes>

--- a/Samples/SampleWdpClient.UniversalWindows/Package.appxmanifest
+++ b/Samples/SampleWdpClient.UniversalWindows/Package.appxmanifest
@@ -20,10 +20,21 @@
         </uap:DefaultTile>
         <uap:SplashScreen Image="Assets\SplashScreen.png" />
       </uap:VisualElements>
+      <Extensions>
+        <uap:Extension Category="windows.fileTypeAssociation">
+          <uap:FileTypeAssociation Name="apppackagebundle">
+            <uap:EditFlags OpenIsSafe="true" />
+            <uap:SupportedFileTypes>
+              <uap:FileType>.appxbundle</uap:FileType>
+            </uap:SupportedFileTypes>
+          </uap:FileTypeAssociation>
+        </uap:Extension>
+      </Extensions>
     </Application>
   </Applications>
   <Capabilities>
     <Capability Name="internetClient" />
     <Capability Name="privateNetworkClientServer" />
+    <uap:Capability Name="removableStorage" />
   </Capabilities>
 </Package>


### PR DESCRIPTION
This is preemptive to allow for adding a sample of installing an app.  Without this association, the sample will be unable to open the apppackage bundle file.