### PR TITLE
BREAKING CHANGE: ConnectAsync(updateConnection)

### DIFF
--- a/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper.Shared/DevicePortal.cs
+++ b/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper.Shared/DevicePortal.cs
@@ -189,7 +189,7 @@ namespace Microsoft.Tools.WindowsDevicePortal
         public async Task ConnectAsync(
             string ssid = null,
             string ssidKey = null,
-            bool updateConnection = true,
+            bool updateConnection = false,
 #if WINDOWS_UWP
             Certificate manualCertificate = null)
 #else


### PR DESCRIPTION
Per discussion in issue #209:

The new ConnectAsync() behavior defaults to updateConnection == false. Most impacted are HoloLens and IoT devices which support a localhost connection (via USB) from the PC to the device.

To use the old behavior, add "updateConnection: true" to your ConnectAsync() arguments.

This change resolves #209.