### PR TITLE
Wrap serialization errors as DevicePortalException for easier catching

### DIFF
--- a/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper.Shared/Exceptions/DevicePortalException.cs
+++ b/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper.Shared/Exceptions/DevicePortalException.cs
@@ -34,6 +34,16 @@ namespace Microsoft.Tools.WindowsDevicePortal
         /// <summary>
         /// Initializes a new instance of the <see cref="DevicePortalException"/> class.
         /// </summary>
+        /// <param name="baseException">A base exception that we are converting to a DevicePortalException.</param>
+        public DevicePortalException(Exception baseException)
+        {
+            this.HResult = baseException.HResult;
+            this.Reason = baseException.Message;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DevicePortalException"/> class.
+        /// </summary>
         /// <param name="statusCode">The Http status code.</param>
         /// <param name="errorResponse">Http parsed error response message.</param>
         /// <param name="requestUri">Request URI which threw the exception.</param>
@@ -97,6 +107,11 @@ namespace Microsoft.Tools.WindowsDevicePortal
         /// Gets a reason for the exception.
         /// </summary>
         public string Reason { get; private set; }
+
+        /// <summary>
+        /// Message override to return Reason.
+        /// </summary>
+        public override string Message { get { return this.Reason; } }
 
         /// <summary>
         /// Gets the request URI that threw the exception.

--- a/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper.Shared/HttpRest/ResponseHelpers.cs
+++ b/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper.Shared/HttpRest/ResponseHelpers.cs
@@ -84,11 +84,11 @@ namespace Microsoft.Tools.WindowsDevicePortal
                     {
                         response = serializer.ReadObject(dataStream);
                     }
-                    catch (SerializationException)
+                    catch (SerializationException e)
                     {
                         // Assert on serialization failure.
                         Debug.Assert(false);
-                        throw;
+                        throw new DevicePortalException(e);
                     }
 
                     data = (T)response;


### PR DESCRIPTION
I'd like to get others' feedback on if this is a good change or not.

Basically, the approach would be to try and catch and rethrow more errors as DevicePortalException so that callers of WDPW can more consistently catch exceptions and diagnose issues with the wrapper.

It is a slight breaking change for anyone that was expecting SerializationException before though.