### PR TITLE
Minor fix to avoid exception in error parsing case

### DIFF
--- a/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper.Shared/Exceptions/DevicePortalException.cs
+++ b/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper.Shared/Exceptions/DevicePortalException.cs
@@ -153,18 +153,21 @@ namespace Microsoft.Tools.WindowsDevicePortal
                     {
                         HttpErrorResponse errorResponse = DevicePortal.ReadJsonStream<HttpErrorResponse>(dataStream);
 
-                        error.HResult = errorResponse.ErrorCode;
-                        error.Reason = errorResponse.ErrorMessage;
-
-                        // If we didn't get the Hresult and reason from these properties, try the other ones.
-                        if (error.HResult == 0)
+                        if (errorResponse != null)
                         {
-                            error.HResult = errorResponse.Code;
-                        }
+                            error.HResult = errorResponse.ErrorCode;
+                            error.Reason = errorResponse.ErrorMessage;
 
-                        if (string.IsNullOrEmpty(error.Reason))
-                        {
-                            error.Reason = errorResponse.Reason;
+                            // If we didn't get the Hresult and reason from these properties, try the other ones.
+                            if (error.HResult == 0)
+                            {
+                                error.HResult = errorResponse.Code;
+                            }
+
+                            if (string.IsNullOrEmpty(error.Reason))
+                            {
+                                error.Reason = errorResponse.Reason;
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
The exception is caught anyways but this is a slight perf optimization and helps if debugging with break on first chance exceptions.