### PR TITLE
Return null instead of empty stream from Post/Delete/Put requests

### DIFF
--- a/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper.Shared/HoloLens/PerceptionSimulationPlayback.cs
+++ b/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper.Shared/HoloLens/PerceptionSimulationPlayback.cs
@@ -192,6 +192,7 @@ namespace Microsoft.Tools.WindowsDevicePortal
 
             using (Stream dataStream = await this.GetAsync(uri))
             {
+                if (dataStream != null)
                 {
                     // Try to get the session state.
                     try

--- a/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper.Shared/HoloLens/PerceptionSimulationRecording.cs
+++ b/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper.Shared/HoloLens/PerceptionSimulationRecording.cs
@@ -101,6 +101,7 @@ namespace Microsoft.Tools.WindowsDevicePortal
 
             using (Stream dataStream = await this.GetAsync(uri))
             {
+                if (dataStream != null)
                 {
                     DataContractJsonSerializer serializer = new DataContractJsonSerializer(typeof(HolographicSimulationError));
                     HolographicSimulationError error = null;

--- a/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper/HttpRest/RestDelete.cs
+++ b/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper/HttpRest/RestDelete.cs
@@ -54,6 +54,10 @@ namespace Microsoft.Tools.WindowsDevicePortal
 
                             // Ensure we return with the stream pointed at the origin.
                             dataStream.Position = 0;
+                            if (dataStream.Length == 0)
+                            {
+                                dataStream = null;
+                            }
                         }
                     }
                 }

--- a/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper/HttpRest/RestPost.cs
+++ b/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper/HttpRest/RestPost.cs
@@ -83,6 +83,10 @@ namespace Microsoft.Tools.WindowsDevicePortal
 
                             // Ensure we return with the stream pointed at the origin.
                             responseDataStream.Position = 0;
+                            if (responseDataStream.Length == 0)
+                            {
+                                responseDataStream = null;
+                            }
                         }
                     }
                 }

--- a/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper/HttpRest/RestPut.cs
+++ b/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper/HttpRest/RestPut.cs
@@ -58,6 +58,10 @@ namespace Microsoft.Tools.WindowsDevicePortal
 
                             // Ensure we return with the stream pointed at the origin.
                             dataStream.Position = 0;
+                            if(dataStream.Length == 0)
+                            {
+                                dataStream = null;
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Fixes some kind of cases when Windows Device Portal returns empty stream, for an example after successful launching an app