### PR TITLE
Fix bug that user was not able to get certificate

### DIFF
--- a/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper/CertificateHandling.cs
+++ b/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper/CertificateHandling.cs
@@ -43,6 +43,7 @@ namespace Microsoft.Tools.WindowsDevicePortal
                 using (MemoryStream outStream = new MemoryStream())
                 {
                     await stream.CopyToAsync(outStream);
+                    outStream.Position = 0;
                     using (BinaryReader reader = new BinaryReader(outStream))
                     {
                         byte[] certData = reader.ReadBytes((int)outStream.Length);


### PR DESCRIPTION
The GetCertificate funstion returns a null certificate as the position of the stream is never reset